### PR TITLE
Added autoclosure(escaping) variants of the logging methods.

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,6 +173,14 @@ The single line closure does not require a `return` declaration since it is impl
 
 > By default, only the `String` returned by the closure will be logged. See the [Formatters](#formatters) section for more information about customizing log message formats.
 
+Willow also accepts autoclosure syntax for message closures.
+
+```swift
+let log = Logger()
+
+log.debug("Debug Message")
+```
+
 #### Multi-Line Closures
 
 Logging a message is easy, but knowing when to add the logic necessary to build a log message and tune it for performance can be a bit tricky. We want to make sure logic is encapsulated and very performant. `Willow` log level closures allow you to cleanly wrap all the logic to build up the message.

--- a/Source/Logger.swift
+++ b/Source/Logger.swift
@@ -68,11 +68,29 @@ public class Logger {
     }
 
     /**
+     Writes out the given message using the logger configuration if the debug log level has an attached writer.
+
+     - parameter message: An autoclosure returning the message to log.
+     */
+    public func debug(@autoclosure(escaping) message: () -> String) {
+        logMessage(message, withLogLevel: .Debug)
+    }
+
+    /**
         Writes out the given message using the logger configuration if the info log level has an attached writer.
 
         - parameter message: A closure returning the message to log.
     */
     public func info(message: () -> String) {
+        logMessage(message, withLogLevel: .Info)
+    }
+
+    /**
+     Writes out the given message using the logger configuration if the info log level has an attached writer.
+
+     - parameter message: An autoclosure returning the message to log.
+     */
+    public func info(@autoclosure(escaping) message: () -> String) {
         logMessage(message, withLogLevel: .Info)
     }
 
@@ -86,11 +104,29 @@ public class Logger {
     }
 
     /**
+     Writes out the given message using the logger configuration if the event log level has an attached writer.
+
+     - parameter message: An autoclosure returning the message to log.
+     */
+    public func event(@autoclosure(escaping) message: () -> String) {
+        logMessage(message, withLogLevel: .Event)
+    }
+
+    /**
         Writes out the given message using the logger configuration if the warn log level has an attached writer.
 
         - parameter message: A closure returning the message to log.
     */
     public func warn(message: () -> String) {
+        logMessage(message, withLogLevel: .Warn)
+    }
+
+    /**
+     Writes out the given message using the logger configuration if the warn log level has an attached writer.
+
+     - parameter message: An autoclosure returning the message to log.
+     */
+    public func warn(@autoclosure(escaping) message: () -> String) {
         logMessage(message, withLogLevel: .Warn)
     }
 
@@ -103,13 +139,17 @@ public class Logger {
         logMessage(message, withLogLevel: .Error)
     }
 
+    public func error(@autoclosure(escaping) message: () -> String) {
+        logMessage(message, withLogLevel: .Error)
+    }
+
     /**
         Writes out the given message closure string with the logger configuration if the log level is allowed.
 
         - parameter message:      A closure returning the message to log.
         - parameter withLogLevel: The log level associated with the message closure.
     */
-    public func logMessage(message: Void -> String, withLogLevel logLevel: LogLevel) {
+    public func logMessage(message: () -> String, withLogLevel logLevel: LogLevel) {
         guard enabled else { return }
 
         switch configuration.executionMethod {
@@ -123,7 +163,7 @@ public class Logger {
 
     // MARK: - Private - Helper Methods
 
-    private func logMessageIfAllowed(message: Void -> String, logLevel: LogLevel) {
+    private func logMessageIfAllowed(message: () -> String, logLevel: LogLevel) {
         guard logLevelAllowed(logLevel) else { return }
         logMessage(message(), logLevel: logLevel)
     }

--- a/Tests/LoggerTests.swift
+++ b/Tests/LoggerTests.swift
@@ -296,6 +296,81 @@ class SynchronousLoggerLogLevelTestCase: SynchronousLoggerTestCase {
         // Then
         XCTAssertEqual(writer.actualNumberOfWrites, 10, "Actual number of writes should be 10")
     }
+
+    func testThatItLogsAsExpectedWithAutoclosureDebugLogLevel() {
+        // Given
+        let (log, writer) = logger(logLevel: .Debug)
+
+        // When
+        log.debug ( "" )
+        log.info ( "" )
+        log.event ( "" )
+        log.warn ( "" )
+        log.error ( "" )
+
+        // Then
+        XCTAssertEqual(writer.actualNumberOfWrites, 1, "Actual number of writes should be 1")
+    }
+
+    func testThatItLogsAsExpectedWithAutoclosureInfoLogLevel() {
+        // Given
+        let (log, writer) = logger(logLevel: .Info)
+
+        // When
+        log.debug ( "" )
+        log.info ( "" )
+        log.event ( "" )
+        log.warn ( "" )
+        log.error ( "" )
+
+        // Then
+        XCTAssertEqual(writer.actualNumberOfWrites, 1, "Actual number of writes should be 1")
+    }
+
+    func testThatItLogsAsExpectedWithAutoclosureEventLogLevel() {
+        // Given
+        let (log, writer) = logger(logLevel: .Event)
+
+        // When
+        log.debug ( "" )
+        log.info ( "" )
+        log.event ( "" )
+        log.warn ( "" )
+        log.error ( "" )
+
+        // Then
+        XCTAssertEqual(writer.actualNumberOfWrites, 1, "Actual number of writes should be 1")
+    }
+
+    func testThatItLogsAsExpectedWithAutoclosureWarnLogLevel() {
+        // Given
+        let (log, writer) = logger(logLevel: .Warn)
+
+        // When
+        log.debug ( "" )
+        log.info ( "" )
+        log.event ( "" )
+        log.warn ( "" )
+        log.error ( "" )
+
+        // Then
+        XCTAssertEqual(writer.actualNumberOfWrites, 1, "Actual number of writes should be 1")
+    }
+
+    func testThatItLogsAsExpectedWithAutoclosureErrorLogLevel() {
+        // Given
+        let (log, writer) = logger(logLevel: .Error)
+
+        // When
+        log.debug ( "" )
+        log.info ( "" )
+        log.event ( "" )
+        log.warn ( "" )
+        log.error ( "" )
+
+        // Then
+        XCTAssertEqual(writer.actualNumberOfWrites, 1, "Actual number of writes should be 1")
+    }
 }
 
 // MARK: -

--- a/Tests/LoggerTests.swift
+++ b/Tests/LoggerTests.swift
@@ -302,11 +302,11 @@ class SynchronousLoggerLogLevelTestCase: SynchronousLoggerTestCase {
         let (log, writer) = logger(logLevel: .Debug)
 
         // When
-        log.debug ( "" )
-        log.info ( "" )
-        log.event ( "" )
-        log.warn ( "" )
-        log.error ( "" )
+        log.debug("")
+        log.info("")
+        log.event("")
+        log.warn("")
+        log.error("")
 
         // Then
         XCTAssertEqual(writer.actualNumberOfWrites, 1, "Actual number of writes should be 1")
@@ -317,11 +317,11 @@ class SynchronousLoggerLogLevelTestCase: SynchronousLoggerTestCase {
         let (log, writer) = logger(logLevel: .Info)
 
         // When
-        log.debug ( "" )
-        log.info ( "" )
-        log.event ( "" )
-        log.warn ( "" )
-        log.error ( "" )
+        log.debug("")
+        log.info("")
+        log.event("")
+        log.warn("")
+        log.error("")
 
         // Then
         XCTAssertEqual(writer.actualNumberOfWrites, 1, "Actual number of writes should be 1")
@@ -332,11 +332,11 @@ class SynchronousLoggerLogLevelTestCase: SynchronousLoggerTestCase {
         let (log, writer) = logger(logLevel: .Event)
 
         // When
-        log.debug ( "" )
-        log.info ( "" )
-        log.event ( "" )
-        log.warn ( "" )
-        log.error ( "" )
+        log.debug("")
+        log.info("")
+        log.event("")
+        log.warn("")
+        log.error("")
 
         // Then
         XCTAssertEqual(writer.actualNumberOfWrites, 1, "Actual number of writes should be 1")
@@ -347,11 +347,11 @@ class SynchronousLoggerLogLevelTestCase: SynchronousLoggerTestCase {
         let (log, writer) = logger(logLevel: .Warn)
 
         // When
-        log.debug ( "" )
-        log.info ( "" )
-        log.event ( "" )
-        log.warn ( "" )
-        log.error ( "" )
+        log.debug("")
+        log.info("")
+        log.event("")
+        log.warn("")
+        log.error("")
 
         // Then
         XCTAssertEqual(writer.actualNumberOfWrites, 1, "Actual number of writes should be 1")
@@ -362,11 +362,11 @@ class SynchronousLoggerLogLevelTestCase: SynchronousLoggerTestCase {
         let (log, writer) = logger(logLevel: .Error)
 
         // When
-        log.debug ( "" )
-        log.info ( "" )
-        log.event ( "" )
-        log.warn ( "" )
-        log.error ( "" )
+        log.debug("")
+        log.info("")
+        log.event("")
+        log.warn("")
+        log.error("")
 
         // Then
         XCTAssertEqual(writer.actualNumberOfWrites, 1, "Actual number of writes should be 1")


### PR DESCRIPTION
Allows callers to use a more normal log.debug("") syntax.
