### PR TITLE
Documentation - Single Line Closure Updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,27 @@ All notable changes to this project will be documented in this file.
 
 #### 1.x Releases
 
-* `1.0.x` Releases - [1.0.0](#100)
+- `1.1.x` Releases - [1.1.0](#110)
+- `1.0.x` Releases - [1.0.0](#100)
 
 ---
+
+## [1.1.0](https://github.com/Nike-Inc/Willow/releases/tag/1.1.0)
+
+Released on 2016-07-11. All issues associated with this milestone can be found using this
+[filter](https://github.com/Nike-Inc/Willow/milestone/1?closed=1).
+
+#### Added
+
+- New `autoclosure(escaping)` variants of the logging methods.
+  - Added by [Dave Camp](https://github.com/AtomicCat) in Pull Request
+  [#3](https://github.com/Nike-Inc/Willow/pull/3).
+
+#### Updated
+
+- The README to explain the differences between autoclosure and closure APIs.
+  - Updated by [Christian Noon](https://github.com/cnoon) in Pull Request
+  [#4](https://github.com/Nike-Inc/Willow/pull/4).
 
 ## [1.0.0](https://github.com/Nike-Inc/Willow/releases/tag/1.0.0)
 

--- a/README.md
+++ b/README.md
@@ -157,29 +157,30 @@ The logging syntax of Willow was optimized to make logging as lightweight and ea
 ```swift
 let log = Logger()
 
-log.debug { "Debug Message" }
-// Debug Message
-log.info { "Info Message" }
-// Info Message
-log.event { "Event Message" }
-// Event Message
-log.warn { "Warn Message" }
-// Warn Message
-log.error { "Error Message" }
-// Error Message
+// Option 1
+log.debug("Debug Message")    // Debug Message
+log.info("Info Message")      // Info Message
+log.event("Event Message")    // Event Message
+log.warn("Warn Message")      // Warn Message
+log.error("Error Message")    // Error Message
+
+// or
+
+// Option 2
+log.debug { "Debug Message" } // Debug Message
+log.info { "Info Message" }   // Info Message
+log.event { "Event Message" } // Event Message
+log.warn { "Warn Message" }   // Warn Message
+log.error { "Error Message" } // Error Message
 ```
 
-The single line closure does not require a `return` declaration since it is implied in Swift. This makes it very easy to declare a closure. There are some VERY important performance considerations which is why Willow only accepts closures for all the Logger convenience methods. See the [Closure Performance](#closure-performance) section for more information.
+Both of these approaches are equivalent. The first set of APIs accept autoclosures and the second set accept closures.
 
-> By default, only the `String` returned by the closure will be logged. See the [Formatters](#formatters) section for more information about customizing log message formats.
+> Feel free to use whichever syntax you prefer for your project. Also, by default, only the `String` returned by the closure will be logged. See the [Formatters](#formatters) section for more information about customizing log message formats.
 
-Willow also accepts autoclosure syntax for message closures.
+The reason both sets of APIs use closures to extract the log message is performance. 
 
-```swift
-let log = Logger()
-
-log.debug("Debug Message")
-```
+> There are some VERY important performance considerations when designing a logging solution that are described in more detail in the [Closure Performance](#closure-performance) section.
 
 #### Multi-Line Closures
 
@@ -204,8 +205,6 @@ log.info {
 #### Closure Performance
 
 Willow works exclusively with logging closures to ensure the maximum performance in all situations. Closures defer the execution of all the logic inside the closure until absolutely necessary, including the string evaluation itself. In cases where the Logger instance is disabled, log execution time was reduced by 97% over the traditional log message methods taking a `String` parameter. Additionally, the overhead for creating a closure was measured at 1% over the traditional method making it negligible. In summary, closures allow Willow to be extremely performant in all situations.
-
-> Unfortunately, it is not possible to utilize `@autoclosure` in this scenario. Swift 1.1 allows `@autoclosure` declaration, but Swift 1.2+ does not, due to the way Willow supports Synchronous and Asynchronous logging. The Swift 1.2 `@autoclosure` declaration implies a `@noescape` which conflicts with the internal dispatch queue.
 
 ### Disabling a Logger
 
@@ -419,7 +418,7 @@ Finally, using the new log level is a simple as...
 
 ```swift
 let log = Logger()
-log.verbose { "My first verbose log message!" }
+log.verbose("My first verbose log message!")
 ```
 
 > The `All` log level contains a bitmask where all bits are set to 1. This means that the `All` log level will contain all custom log levels automatically.

--- a/Source/Info-tvOS.plist
+++ b/Source/Info-tvOS.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.0.0</string>
+	<string>1.1.0</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>

--- a/Source/Info.plist
+++ b/Source/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.0.0</string>
+	<string>1.1.0</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>

--- a/Source/Logger.swift
+++ b/Source/Logger.swift
@@ -68,10 +68,10 @@ public class Logger {
     }
 
     /**
-     Writes out the given message using the logger configuration if the debug log level has an attached writer.
+        Writes out the given message using the logger configuration if the debug log level has an attached writer.
 
-     - parameter message: An autoclosure returning the message to log.
-     */
+        - parameter message: An autoclosure returning the message to log.
+    */
     public func debug(@autoclosure(escaping) message: () -> String) {
         logMessage(message, withLogLevel: .Debug)
     }
@@ -86,10 +86,10 @@ public class Logger {
     }
 
     /**
-     Writes out the given message using the logger configuration if the info log level has an attached writer.
+        Writes out the given message using the logger configuration if the info log level has an attached writer.
 
-     - parameter message: An autoclosure returning the message to log.
-     */
+        - parameter message: An autoclosure returning the message to log.
+    */
     public func info(@autoclosure(escaping) message: () -> String) {
         logMessage(message, withLogLevel: .Info)
     }
@@ -104,10 +104,10 @@ public class Logger {
     }
 
     /**
-     Writes out the given message using the logger configuration if the event log level has an attached writer.
+        Writes out the given message using the logger configuration if the event log level has an attached writer.
 
-     - parameter message: An autoclosure returning the message to log.
-     */
+        - parameter message: An autoclosure returning the message to log.
+    */
     public func event(@autoclosure(escaping) message: () -> String) {
         logMessage(message, withLogLevel: .Event)
     }
@@ -122,10 +122,10 @@ public class Logger {
     }
 
     /**
-     Writes out the given message using the logger configuration if the warn log level has an attached writer.
+        Writes out the given message using the logger configuration if the warn log level has an attached writer.
 
-     - parameter message: An autoclosure returning the message to log.
-     */
+        - parameter message: An autoclosure returning the message to log.
+    */
     public func warn(@autoclosure(escaping) message: () -> String) {
         logMessage(message, withLogLevel: .Warn)
     }
@@ -139,6 +139,11 @@ public class Logger {
         logMessage(message, withLogLevel: .Error)
     }
 
+    /**
+        Writes out the given message using the logger configuration if the error log level has an attached writer.
+
+        - parameter message: An autoclosure returning the message to log.
+    */
     public func error(@autoclosure(escaping) message: () -> String) {
         logMessage(message, withLogLevel: .Error)
     }


### PR DESCRIPTION
This PR adds a public docstring for the new `error` API and updates the public docstring formatting to be consistent. It also updates the README to be more tailored to the autoclosure APIs.
