### PR TITLE
updating README build badge to represent master branch status

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Willow
 
-[![Build Status](https://travis-ci.org/Nike-Inc/Willow.svg)](https://travis-ci.org/Nike-Inc/Willow)
+[![Build Status](https://travis-ci.org/Nike-Inc/Willow.svg?branch=master)](https://travis-ci.org/Nike-Inc/Willow)
 [![CocoaPods Compatible](https://img.shields.io/cocoapods/v/Willow.svg)](https://img.shields.io/cocoapods/v/Willow.svg)
 [![Carthage Compatible](https://img.shields.io/badge/Carthage-compatible-4BC51D.svg?style=flat)](https://github.com/Carthage/Carthage)
 [![Platform](https://img.shields.io/cocoapods/p/Willow.svg?style=flat)](http://cocoadocs.org/docsets/Willow)


### PR DESCRIPTION
@cnoon have a look. this will ensure that the build badge in the README always reflects the status of the master branch and isn't affected by other WIP branch builds.
