### PR TITLE
Fix - Xcode 8 Beta 3 Issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ Willow is a powerful, yet lightweight logging library written in Swift.
 ## Requirements
 
 - iOS 9.0+ / Mac OS X 10.11+ / tvOS 9.0+ / watchOS 2.0+
-- Xcode 8.0 beta 2+
+- Xcode 8.0 beta 3+
 
 ## Communication
 

--- a/Tests/LoggerConfigurationTests.swift
+++ b/Tests/LoggerConfigurationTests.swift
@@ -40,7 +40,7 @@ class LoggerConfigurationTestCase: XCTestCase {
         for logLevel in logLevels {
             XCTAssertEqual(configuration.modifiers[logLevel]?.count, 1)
 
-            if let modifiers = configuration.modifiers[logLevel] where modifiers.count == 1 {
+            if let modifiers = configuration.modifiers[logLevel], modifiers.count == 1 {
                 XCTAssertTrue(modifiers[0] is TimestampModifier)
             }
         }
@@ -50,7 +50,7 @@ class LoggerConfigurationTestCase: XCTestCase {
         for rawValue in UInt(0)..<UInt(configuration.writers.count) {
             let logLevel = LogLevel(rawValue: rawValue)
 
-            if let writers = configuration.writers[logLevel] where writers.count == 1 {
+            if let writers = configuration.writers[logLevel], writers.count == 1 {
                 XCTAssertTrue(writers[0] is ConsoleWriter)
             }
         }
@@ -69,7 +69,7 @@ class LoggerConfigurationTestCase: XCTestCase {
         for logLevel in logLevels {
             XCTAssertEqual(configuration.modifiers[logLevel]?.count, 2)
 
-            if let modifiers = configuration.modifiers[logLevel] where modifiers.count == 2 {
+            if let modifiers = configuration.modifiers[logLevel], modifiers.count == 2 {
                 XCTAssertTrue(modifiers[0] is TimestampModifier)
                 XCTAssertTrue(modifiers[1] is ColorModifier)
             }
@@ -80,7 +80,7 @@ class LoggerConfigurationTestCase: XCTestCase {
         for rawValue in UInt(0)..<UInt(configuration.writers.count) {
             let logLevel = LogLevel(rawValue: rawValue)
 
-            if let writers = configuration.writers[logLevel] where writers.count == 1 {
+            if let writers = configuration.writers[logLevel], writers.count == 1 {
                 XCTAssertTrue(writers[0] is ConsoleWriter)
             }
         }

--- a/Tests/LoggerTests.swift
+++ b/Tests/LoggerTests.swift
@@ -121,7 +121,7 @@ class AsynchronousLoggerTestCase: SynchronousLoggerTestCase {
         modifiers: [LogLevel: [Modifier]] = [:],
         expectedNumberOfWrites: Int = 1) -> (Logger, AsynchronousTestWriter)
     {
-        let expectation = self.expectation(withDescription: "Test writer should receive expected number of writes")
+        let expectation = self.expectation(description: "Test writer should receive expected number of writes")
         let writer = AsynchronousTestWriter(expectation: expectation, expectedNumberOfWrites: expectedNumberOfWrites)
         let queue = DispatchQueue(label: "async-logger-test-queue", attributes: [.serial, .qosUtility])
 
@@ -394,7 +394,7 @@ class AsynchronousLoggerLogLevelTestCase: AsynchronousLoggerTestCase {
             writer.expectation.fulfill()
         }
 
-        waitForExpectations(withTimeout: timeout, handler: nil)
+        waitForExpectations(timeout: timeout, handler: nil)
 
         // Then
         XCTAssertEqual(writer.actualNumberOfWrites, writer.expectedNumberOfWrites, "Expected should match actual number of writes")
@@ -411,7 +411,7 @@ class AsynchronousLoggerLogLevelTestCase: AsynchronousLoggerTestCase {
         log.warn { "" }
         log.error { "" }
 
-        waitForExpectations(withTimeout: timeout, handler: nil)
+        waitForExpectations(timeout: timeout, handler: nil)
 
         // Then
         XCTAssertEqual(writer.actualNumberOfWrites, writer.expectedNumberOfWrites, "Expected should match actual number of writes")
@@ -428,7 +428,7 @@ class AsynchronousLoggerLogLevelTestCase: AsynchronousLoggerTestCase {
         log.warn { "" }
         log.error { "" }
 
-        waitForExpectations(withTimeout: timeout, handler: nil)
+        waitForExpectations(timeout: timeout, handler: nil)
 
         // Then
         XCTAssertEqual(writer.actualNumberOfWrites, writer.expectedNumberOfWrites, "Expected should match actual number of writes")
@@ -445,7 +445,7 @@ class AsynchronousLoggerLogLevelTestCase: AsynchronousLoggerTestCase {
         log.warn { "" }
         log.error { "" }
 
-        waitForExpectations(withTimeout: timeout, handler: nil)
+        waitForExpectations(timeout: timeout, handler: nil)
 
         // Then
         XCTAssertEqual(writer.actualNumberOfWrites, writer.expectedNumberOfWrites, "Expected should match actual number of writes")
@@ -462,7 +462,7 @@ class AsynchronousLoggerLogLevelTestCase: AsynchronousLoggerTestCase {
         log.warn { "" }
         log.error { "" }
 
-        waitForExpectations(withTimeout: timeout, handler: nil)
+        waitForExpectations(timeout: timeout, handler: nil)
 
         // Then
         XCTAssertEqual(writer.actualNumberOfWrites, writer.expectedNumberOfWrites, "Expected should match actual number of writes")
@@ -479,7 +479,7 @@ class AsynchronousLoggerLogLevelTestCase: AsynchronousLoggerTestCase {
         log.warn { "" }
         log.error { "" }
 
-        waitForExpectations(withTimeout: timeout, handler: nil)
+        waitForExpectations(timeout: timeout, handler: nil)
 
         // Then
         XCTAssertEqual(writer.actualNumberOfWrites, writer.expectedNumberOfWrites, "Expected should match actual number of writes")
@@ -497,7 +497,7 @@ class AsynchronousLoggerLogLevelTestCase: AsynchronousLoggerTestCase {
         log.warn { "" }
         log.error { "" }
 
-        waitForExpectations(withTimeout: timeout, handler: nil)
+        waitForExpectations(timeout: timeout, handler: nil)
 
         // Then
         XCTAssertEqual(writer.actualNumberOfWrites, writer.expectedNumberOfWrites, "Expected should match actual number of writes")
@@ -533,7 +533,7 @@ class AsynchronousLoggerLogLevelTestCase: AsynchronousLoggerTestCase {
             return ""
         }
 
-        waitForExpectations(withTimeout: timeout, handler: nil)
+        waitForExpectations(timeout: timeout, handler: nil)
 
         // Then
         XCTAssertEqual(writer.actualNumberOfWrites, writer.expectedNumberOfWrites)


### PR DESCRIPTION
This PR fixes up compiler errors due to XCTest APIs changes and also fixes up warnings due to `where` clause being replaced with comma separators. Also bumped the Xcode 8 version in the README.
