### PR TITLE
Feature - Refactoring Modifiers and Writers

### DIFF
--- a/Example/Frameworks/Database/Logger.swift
+++ b/Example/Frameworks/Database/Logger.swift
@@ -47,7 +47,7 @@ extension Logger {
 
 /// The single `Logger` instance used throughout Database.
 public var log: Logger! = {
-    struct PrefixModifier: Modifier {
+    struct PrefixModifier: LogMessageModifier {
         func modifyMessage(_ message: String, with: LogLevel) -> String {
             return "[Database] => \(message)"
         }
@@ -70,7 +70,7 @@ public var log: Logger! = {
     let warnColorModifier = ColorModifier(foregroundColor: orange, backgroundColor: nil)
     let errorColorModifier = ColorModifier(foregroundColor: red, backgroundColor: nil)
 
-    let modifiers: [LogLevel: [Modifier]] = [
+    let modifiers: [LogLevel: [LogMessageModifier]] = [
         .sql: [prefixModifier, timestampModifier, sqlColorModifier],
         .debug: [prefixModifier, timestampModifier, debugColorModifier],
         .info: [prefixModifier, timestampModifier, infoColorModifier],

--- a/Example/Frameworks/Network/Logger.swift
+++ b/Example/Frameworks/Network/Logger.swift
@@ -28,7 +28,7 @@ import Willow
 
 /// The single `Logger` instance used throughout Network.
 public var log: Logger = {
-    struct PrefixModifier: Modifier {
+    struct PrefixModifier: LogMessageModifier {
         func modifyMessage(_ message: String, with: LogLevel) -> String {
             return "[Network] => \(message)"
         }
@@ -49,7 +49,7 @@ public var log: Logger = {
     let warnColorModifier = ColorModifier(foregroundColor: orange, backgroundColor: nil)
     let errorColorModifier = ColorModifier(foregroundColor: red, backgroundColor: nil)
 
-    let modifiers: [LogLevel: [Modifier]] = [
+    let modifiers: [LogLevel: [LogMessageModifier]] = [
         .debug: [prefixModifier, timestampModifier, debugColorModifier],
         .info: [prefixModifier, timestampModifier, infoColorModifier],
         .event: [prefixModifier, timestampModifier, eventColorModifier],

--- a/Example/iOS Example/WillowConfiguration.swift
+++ b/Example/iOS Example/WillowConfiguration.swift
@@ -34,7 +34,7 @@ struct WillowConfiguration {
 
     // MARK: Modifiers
 
-    private struct PrefixModifier: Modifier {
+    private struct PrefixModifier: LogMessageModifier {
         let prefix: String
 
         init(prefix: String) {
@@ -46,13 +46,13 @@ struct WillowConfiguration {
         }
     }
 
-    private struct WarningPrefixModifier: Modifier {
+    private struct WarningPrefixModifier: LogMessageModifier {
         func modifyMessage(_ message: String, with: LogLevel) -> String {
             return "🚨🚨🚨 \(message)"
         }
     }
 
-    private struct ErrorPrefixModifier: Modifier {
+    private struct ErrorPrefixModifier: LogMessageModifier {
         func modifyMessage(_ message: String, with: LogLevel) -> String {
             return "💣💥💣💥 \(message)"
         }
@@ -67,7 +67,7 @@ struct WillowConfiguration {
         coloredOutputEnabled: Bool = true,
         asynchronous: Bool = false)
     {
-        let writers: [LogLevel: [Writer]] = [.all: [ConsoleWriter()]]
+        let writers: [LogLevel: [LogMessageWriter]] = [.all: [ConsoleWriter()]]
         let executionMethod: LoggerConfiguration.ExecutionMethod
 
         if asynchronous {
@@ -111,7 +111,7 @@ struct WillowConfiguration {
         backgroundColor: UIColor? = nil,
         prefix: String,
         modifierLogLevel: LogLevel,
-        writers: [LogLevel: [Writer]],
+        writers: [LogLevel: [LogMessageWriter]],
         executionMethod: LoggerConfiguration.ExecutionMethod)
         -> Logger
     {
@@ -119,9 +119,9 @@ struct WillowConfiguration {
         let timestampModifier = TimestampModifier()
         let colorModifier = ColorModifier(foregroundColor: foregroundColor, backgroundColor: backgroundColor)
 
-        let modifiers: [LogLevel: [Modifier]] = {
-            let modifiers: [Modifier] = {
-                var modifiers: [Modifier] = [prefixModifier, timestampModifier]
+        let modifiers: [LogLevel: [LogMessageModifier]] = {
+            let modifiers: [LogMessageModifier] = {
+                var modifiers: [LogMessageModifier] = [prefixModifier, timestampModifier]
                 if foregroundColor != nil || backgroundColor != nil { modifiers.append(colorModifier) }
                 return modifiers
             }()

--- a/README.md
+++ b/README.md
@@ -25,10 +25,10 @@ Willow is a powerful, yet lightweight logging library written in Swift.
     - [Synchronous and Asynchronous Logging](#synchronous-and-asynchronous-logging)
         - [Synchronous Logging](#synchronous-logging)
         - [Asynchronous Logging](#asynchronous-logging)
-    - [Modifiers](#modifiers)
+    - [Log Message Modifiers](#log-message-modifiers)
         - [Color Modifiers](#color-modifiers)
         - [Multiple Modifiers](#multiple-modifiers)
-    - [Writers](#writers)
+    - [Log Message Writers](#log-message-writers)
         - [Multiple Writers](#multiple-writers)
         - [Per LogLevel Writers](#per-loglevel-writers)
 - [Advanced Usage](#advanced-usage)
@@ -241,20 +241,20 @@ Asynchronous logging should be used for deployment builds of your application or
 
 > These are large generalizations about the typical use cases for one approach versus the other. Before making a final decision about which approach to use when, you should really break down your use case in detail.
 
-### Modifiers
+### Log Message Modifiers
 
-Log message customization is something that `Willow` specializes in. Some devs want to add a prefix to their library output, some want different timestamp formats, some even want colors! There's no way to predict all the types of custom formatting teams are going to want to use. This is where `Modifier` objects come in.
+Log message customization is something that `Willow` specializes in. Some devs want to add a prefix to their library output, some want different timestamp formats, some even want colors! There's no way to predict all the types of custom formatting teams are going to want to use. This is where `LogMessageModifier` objects come in.
 
 ```swift
-public protocol Modifier {
+public protocol LogMessageModifier {
     func modifyMessage(_ message: String, with logLevel: LogLevel) -> String
 }
 ```
 
-The `Modifier` protocol has only a single API. It receives the `message` and `logLevel` and returns a newly formatted `String`. This is about as flexible as you can get. The `Logger` allows you to pass in your own `Modifier` objects and apply them to a `LogLevel`. Let's walk through a simple example for adding a prefix to only the `debug` and `info` log levels.
+The `LogMessageModifier` protocol has only a single API. It receives the `message` and `logLevel` and returns a newly formatted `String`. This is about as flexible as you can get. The `Logger` allows you to pass in your own `LogMessageModifier` objects and apply them to a `LogLevel`. Let's walk through a simple example for adding a prefix to only the `debug` and `info` log levels.
 
 ```swift
-class PrefixModifier: Modifier {
+class PrefixModifier: LogMessageModifier {
     func modifyMessage(_ message: String, with logLevel: Logger.LogLevel) -> String {
         return "[Willow] \(message)"
     }
@@ -262,7 +262,7 @@ class PrefixModifier: Modifier {
 
 let prefixModifier = PrefixModifier()
 
-let modifiers: [Logger.LogLevel: [Modifier]] = [
+let modifiers: [Logger.LogLevel: [LogMessageModifier]] = [
     .debug: [prefixModifier],
     .info: [prefixModifier]
 ]
@@ -271,11 +271,11 @@ let configuration = LoggerConfiguration(modifiers: modifiers)
 let log = Logger(configuration: configuration)
 ```
 
-`Modifier` objects are very powerful and can manipulate the message in any way.
+`LogMessageModifier` objects are very powerful and can manipulate the message in any way.
 
 #### Color Modifiers
 
-There is a special `Modifier` in `Willow` called a `ColorModifier`. It was designed to take a foreground and backround color in the form of a `UIColor` or `NSColor`. It then formats the message to match the coloring scheme of the [XcodeColors](https://github.com/robbiehanson/XcodeColors) plugin. This allows you to change the foreground and background colors of logging output in the Xcode console. This can make it much easier to dig through thousands of lines of logging output.
+There is a special `LogMessageModifier` in `Willow` called a `ColorModifier`. It was designed to take a foreground and backround color in the form of a `UIColor` or `NSColor`. It then formats the message to match the coloring scheme of the [XcodeColors](https://github.com/robbiehanson/XcodeColors) plugin. This allows you to change the foreground and background colors of logging output in the Xcode console. This can make it much easier to dig through thousands of lines of logging output.
 
 ```swift
 let purple = UIColor.purple()
@@ -286,7 +286,7 @@ let red = UIColor.red()
 let white = UIColor.white()
 let black = UIColor.black()
 
-let colorModifiers: [Logger.LogLevel: [Modifier]] = [
+let colorModifiers: [Logger.LogLevel: [LogMessageModifier]] = [
     LogLevel.debug: [ColorModifier(foregroundColor: purple, backgroundColor: nil)],
     LogLevel.info: [ColorModifier(foregroundColor: blue, backgroundColor: nil)],
     LogLevel.event: [ColorModifier(foregroundColor: green, backgroundColor: nil)],
@@ -302,7 +302,7 @@ let log = Logger(configuration: configuration)
 
 #### Multiple Modifiers
 
-Multiple `Modifier` objects can be stacked together onto a single log level to perform multiple actions. Let's walk through using the `TimestampModifier` (prefixes the message with a timestamp) in combination with the `ColorModifier` objects from the previous example.
+Multiple `LogMessageModifier` objects can be stacked together onto a single log level to perform multiple actions. Let's walk through using the `TimestampModifier` (prefixes the message with a timestamp) in combination with the `ColorModifier` objects from the previous example.
 
 ```swift
 let purple = UIColor.purple()
@@ -315,7 +315,7 @@ let black = UIColor.black()
 
 let timestampModifier = TimestampModifier()
 
-let modifiers: [Logger.LogLevel: [Modifier]] = [
+let modifiers: [Logger.LogLevel: [LogMessageModifier]] = [
     LogLevel.debug: [timestampModifier, ColorModifier(foregroundColor: purple, backgroundColor: nil)],
     LogLevel.info: [timestampModifier, ColorModifier(foregroundColor: blue, backgroundColor: nil)],
     LogLevel.event: [timestampModifier, ColorModifier(foregroundColor: green, backgroundColor: nil)],
@@ -327,25 +327,25 @@ let configuration = LoggerConfiguration(modifiers: modifiers)
 let log = Logger(configuration: configuration)
 ```
 
-`Willow` doesn't have any hard limits on the total number of `Modifier` objects that can be applied to a single log level. Just keep in mind that performance is key.
+`Willow` doesn't have any hard limits on the total number of `LogMessageModifier` objects that can be applied to a single log level. Just keep in mind that performance is key.
 
 > The default `ConsoleWriter` will execute the modifiers in the same order they were added into the `Array`. In the previous example, Willow would log a much different message if the `ColorModifier` was inserted before the `TimestampModifier`.
 
-### Writers
+### Log Message Writers
 
-Writing log messages to various locations is an essential feature of any robust logging library. This is made possible in `Willow` through the `Writer` protocol.
+Writing log messages to various locations is an essential feature of any robust logging library. This is made possible in `Willow` through the `LogMessageWriter` protocol.
 
 ```swift
-public protocol Writer {
-    func writeMessage(_ message: String, logLevel: LogLevel, modifiers: [Modifier]?)
+public protocol LogMessageWriter {
+    func writeMessage(_ message: String, logLevel: LogLevel, modifiers: [LogMessageModifier]?)
 }
 ```
 
-Again, this is an extremely lightweight design to allow for ultimate flexibility. As long as your `Writer` classes conform, you can do anything with those log messages that you want. You could write the message to the console, append it to a file, send it to a server, etc. Here's a quick look at the implementation of the default `ConsoleWriter` created by the `Logger` if you don't specify your own.
+Again, this is an extremely lightweight design to allow for ultimate flexibility. As long as your `LogMessageWriter` classes conform, you can do anything with those log messages that you want. You could write the message to the console, append it to a file, send it to a server, etc. Here's a quick look at the implementation of the default `ConsoleWriter` created by the `Logger` if you don't specify your own.
 
 ```swift
-public class ConsoleWriter: Writer {
-    public func writeMessage(_ message: String, logLevel: LogLevel, formatters: [Formatter]?) {
+public class ConsoleWriter: LogMessageWriter {
+    public func writeMessage(_ message: String, logLevel: LogLevel, modifiers: [LogMessageModifier]?) {
     	var mutableMessage = message
         modifiers?.map { mutableMessage = $0.modifyMessage(mutableMessage, with: logLevel) }
         print(mutableMessage)
@@ -355,31 +355,31 @@ public class ConsoleWriter: Writer {
 
 #### Multiple Writers
 
-So what about logging to both a file and the console at the same time? No problem. You can pass multiple `Writer` objects into the `Logger` initializer. The `Logger` will execute each `Writer` in the order it was passed in. For example, let's create a `FileWriter` and combine that with our `ConsoleWriter`.
+So what about logging to both a file and the console at the same time? No problem. You can pass multiple `LogMessageWriter` objects into the `Logger` initializer. The `Logger` will execute each `LogMessageWriter` in the order it was passed in. For example, let's create a `FileWriter` and combine that with our `ConsoleWriter`.
 
 ```swift
-public class FileWriter: Writer {
-    public func writeMessage(_ message: String, logLevel: Logger.LogLevel, modifiers: [Modifier]?) {
+public class FileWriter: LogMessageWriter {
+    public func writeMessage(_ message: String, logLevel: Logger.LogLevel, modifiers: [LogMessageModifier]?) {
 	    var mutableMessage = message
         modifiers?.map { mutableMessage = $0.modifyMessage(mutableMessage, with: logLevel) }
         // Write the formatted message to a file (I'll leave this to you!)
     }
 }
 
-let writers: [LogLevel: Writer] = [.all: [FileWriter(), ConsoleWriter()]]
+let writers: [LogLevel: LogMessageWriter] = [.all: [FileWriter(), ConsoleWriter()]]
 
 let configuration = LoggerConfiguration(writers: writers)
 let log = Logger(configuration: configuration)
 ```
 
-> `Writer` objects can also be selective about which modifiers they want to run for a particular log level. All the examples run all the modifiers, but you can be selective if you want to be.
+> `LogMessageWriter` objects can also be selective about which modifiers they want to run for a particular log level. All the examples run all the modifiers, but you can be selective if you want to be.
 
 #### Per LogLevel Writers
 
-It is also possible to specify different combinations of `Writer` objects for each `LogLevel`. Let's say we want to log `.warn` and `.error` messages to the console, and we want to log all messages to a file writer.
+It is also possible to specify different combinations of `LogMessageWriter` objects for each `LogLevel`. Let's say we want to log `.warn` and `.error` messages to the console, and we want to log all messages to a file writer.
 
 ```swift
-let writers: [LogLevel: Writer] = [
+let writers: [LogLevel: LogMessageWriter] = [
 	.all: [FileWriter()],
 	[.warn, .error]: [ConsoleWriter()]
 ]
@@ -440,7 +440,7 @@ public var log = Logger(configuration: LoggerConfiguration(writers: [.warn, .err
 //=========== Calculator.swift ===========
 import Math
 
-let writers = [.all: [FileWriter(), ConsoleWriter()]]
+let writers: [LogLevel: [LogMessageWriter]] = [.all: [FileWriter(), ConsoleWriter()]]
 var log = Logger(configuration: LoggerConfiguration(writers: writers))
 
 // Replace the Math.log with the Calculator.log to share the same Logger instance
@@ -464,7 +464,7 @@ import Math
 let sharedQueue = DispatchQueue(label: "com.math.logger", attributes: [.serial, .qosUtility])
 
 // Create the Calculator.log with multiple writers and a .Debug log level
-let writers = [.all: [FileWriter(), ConsoleWriter()]]
+let writers: [LogLevel: [LogMessageWriter]] = [.all: [FileWriter(), ConsoleWriter()]]
 let configuration = LoggerConfiguration(
     writers: writers, 
     executionMethod: .Asynchronous(queue: sharedQueue)

--- a/Source/LogMessageModifier.swift
+++ b/Source/LogMessageModifier.swift
@@ -1,5 +1,5 @@
 //
-//  Modifier.swift
+//  LogMessageModifier.swift
 //
 //  Copyright (c) 2015-2016 Nike, Inc. (https://www.nike.com)
 //
@@ -32,16 +32,16 @@ import Cocoa
 public typealias Color = NSColor
 #endif
 
-/// The Modifier protocol defines a single method for modifying a message after it has been constructed. This is
-/// very flexible allowing any object that conforms to modify messages in any way it wants.
-public protocol Modifier {
+/// The LogMessageModifier protocol defines a single method for modifying a log message after it has been constructed.
+/// This is very flexible allowing any object that conforms to modify messages in any way it wants.
+public protocol LogMessageModifier {
     func modifyMessage(_ message: String, with logLevel: LogLevel) -> String
 }
 
 // MARK:
 
 /// The TimestampModifier class applies a timestamp to the beginning of the message.
-public class TimestampModifier: Modifier {
+public class TimestampModifier: LogMessageModifier {
     private let timestampFormatter: DateFormatter = {
         var formatter = DateFormatter()
         formatter.dateFormat = "yyyy-MM-dd HH:mm:ss.SSS"
@@ -71,7 +71,7 @@ public class TimestampModifier: Modifier {
 /// XcodeColors plugin color formatting scheme.
 ///
 /// NOTE: These should only be used with the XcodeColors plugin.
-public class ColorModifier: Modifier {
+public class ColorModifier: LogMessageModifier {
 
     // MARK: Helper Types
 

--- a/Source/LogMessageWriter.swift
+++ b/Source/LogMessageWriter.swift
@@ -1,5 +1,5 @@
 //
-//  Writer.swift
+//  LogMessageWriter.swift
 //
 //  Copyright (c) 2015-2016 Nike, Inc. (https://www.nike.com)
 //
@@ -24,18 +24,18 @@
 
 import Foundation
 
-/// The Writer protocol defines a single API for writing a message. The message can be written in any way the
-/// conforming object sees fit. For example, it could write to the console, write to a file, remote log to a third
+/// The LogMessageWriter protocol defines a single API for writing a log message. The message can be written in any way
+/// the conforming object sees fit. For example, it could write to the console, write to a file, remote log to a third
 /// party service, etc.
-public protocol Writer {
-    func writeMessage(_ message: String, logLevel: LogLevel, modifiers: [Modifier]?)
+public protocol LogMessageWriter {
+    func writeMessage(_ message: String, logLevel: LogLevel, modifiers: [LogMessageModifier]?)
 }
 
 // MARK:
 
 /// The ConsoleWriter class runs all modifiers in the order they were created and prints the resulting message
 /// to the console.
-public class ConsoleWriter: Writer {
+public class ConsoleWriter: LogMessageWriter {
     /// Initializes a console writer instance.
     ///
     /// - returns: A new console writer instance.
@@ -49,7 +49,7 @@ public class ConsoleWriter: Writer {
     /// - parameter message:   The original message to write to the console.
     /// - parameter logLevel:  The log level associated with the message.
     /// - parameter modifiers: The modifier objects to run over the message before writing to the console.
-    public func writeMessage(_ message: String, logLevel: LogLevel, modifiers: [Modifier]?) {
+    public func writeMessage(_ message: String, logLevel: LogLevel, modifiers: [LogMessageModifier]?) {
         var mutableMessage = message
         modifiers?.forEach { mutableMessage = $0.modifyMessage(mutableMessage, with: logLevel) }
 

--- a/Source/LoggerConfiguration.swift
+++ b/Source/LoggerConfiguration.swift
@@ -49,10 +49,10 @@ public struct LoggerConfiguration {
     // MARK: Properties
 
     /// The dictionary of modifiers to apply to each associated log level.
-    public let modifiers: [LogLevel: [Modifier]]
+    public let modifiers: [LogLevel: [LogMessageModifier]]
 
     /// The dictionary of writers to use when messages are written for each associated log level.
-    public let writers: [LogLevel: [Writer]]
+    public let writers: [LogLevel: [LogMessageWriter]]
 
     /// The execution method used when logging a message.
     public let executionMethod: ExecutionMethod
@@ -69,8 +69,8 @@ public struct LoggerConfiguration {
     ///
     /// - returns: A fully initialized logger configuration instance.
     public init(
-        modifiers: [LogLevel: [Modifier]] = [:],
-        writers: [LogLevel: [Writer]] = [.all: [ConsoleWriter()]],
+        modifiers: [LogLevel: [LogMessageModifier]] = [:],
+        writers: [LogLevel: [LogMessageWriter]] = [.all: [ConsoleWriter()]],
         executionMethod: ExecutionMethod = .Synchronous(lock: RecursiveLock()))
     {
         func restructureDictionaryValuesPerBitBasedLogLevel<T>(_ values: [LogLevel: [T]]) -> [LogLevel: [T]] {
@@ -112,8 +112,8 @@ public struct LoggerConfiguration {
         executionMethod: ExecutionMethod = .Synchronous(lock: RecursiveLock()))
         -> LoggerConfiguration
     {
-        let modifiers: [LogLevel: [Modifier]] = [logLevel: [TimestampModifier()]]
-        let writers: [LogLevel: [Writer]] = [logLevel: [ConsoleWriter()]]
+        let modifiers: [LogLevel: [LogMessageModifier]] = [logLevel: [TimestampModifier()]]
+        let writers: [LogLevel: [LogMessageWriter]] = [logLevel: [ConsoleWriter()]]
 
         return LoggerConfiguration(modifiers: modifiers, writers: writers, executionMethod: executionMethod)
     }
@@ -138,7 +138,7 @@ public struct LoggerConfiguration {
 
         let timestampModifier = TimestampModifier()
 
-        let modifiers: [LogLevel: [Modifier]] = [
+        let modifiers: [LogLevel: [LogMessageModifier]] = [
             .debug: [timestampModifier, ColorModifier(foregroundColor: purple, backgroundColor: nil)],
             .info: [timestampModifier, ColorModifier(foregroundColor: blue, backgroundColor: nil)],
             .event: [timestampModifier, ColorModifier(foregroundColor: green, backgroundColor: nil)],
@@ -146,7 +146,7 @@ public struct LoggerConfiguration {
             .error: [timestampModifier, ColorModifier(foregroundColor: red, backgroundColor: nil)]
         ]
 
-        let writers: [LogLevel: [Writer]] = [logLevel: [ConsoleWriter()]]
+        let writers: [LogLevel: [LogMessageWriter]] = [logLevel: [ConsoleWriter()]]
 
         return LoggerConfiguration(modifiers: modifiers, writers: writers, executionMethod: executionMethod)
     }

--- a/Tests/LogLevelTests.swift
+++ b/Tests/LogLevelTests.swift
@@ -54,11 +54,11 @@ extension Logger {
 // MARK:
 // MARK: Helper Test Classes
 
-class TestWriter: Writer {
+class TestWriter: LogMessageWriter {
     private(set) var actualNumberOfWrites: Int = 0
     private(set) var message: String?
 
-    func writeMessage(_ message: String, logLevel: LogLevel, modifiers: [Modifier]?) {
+    func writeMessage(_ message: String, logLevel: LogLevel, modifiers: [LogMessageModifier]?) {
         self.message = message
         actualNumberOfWrites += 1
     }

--- a/Willow.xcodeproj/project.pbxproj
+++ b/Willow.xcodeproj/project.pbxproj
@@ -19,30 +19,30 @@
 		4C83FB2D1AEC1959003FEA49 /* LogLevel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C83FB2C1AEC1959003FEA49 /* LogLevel.swift */; };
 		4C83FB2E1AEC1959003FEA49 /* LogLevel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C83FB2C1AEC1959003FEA49 /* LogLevel.swift */; };
 		4C8835281C82506600F70419 /* Willow.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 4C88351E1C82506600F70419 /* Willow.framework */; };
-		4C8835361C82530300F70419 /* Modifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4CA86F641AEC465E005E6475 /* Modifier.swift */; };
+		4C8835361C82530300F70419 /* LogMessageModifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4CA86F641AEC465E005E6475 /* LogMessageModifier.swift */; };
 		4C8835371C82530300F70419 /* Logger.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4CA86F611AEC4654005E6475 /* Logger.swift */; };
 		4C8835381C82530300F70419 /* LoggerConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4CA86F5E1AEC464A005E6475 /* LoggerConfiguration.swift */; };
 		4C8835391C82530300F70419 /* LogLevel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C83FB2C1AEC1959003FEA49 /* LogLevel.swift */; };
-		4C88353A1C82530300F70419 /* Writer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4CA86F671AEC466A005E6475 /* Writer.swift */; };
+		4C88353A1C82530300F70419 /* LogMessageWriter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4CA86F671AEC466A005E6475 /* LogMessageWriter.swift */; };
 		4C88353B1C82530600F70419 /* Willow.h in Headers */ = {isa = PBXBuildFile; fileRef = 4CA75D421A6C493800275DC5 /* Willow.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		4C88353C1C82530F00F70419 /* LogLevelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4CBE850B1AEA2EFA006A1205 /* LogLevelTests.swift */; };
 		4C88353D1C82530F00F70419 /* ModifierTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C1BBA691A6C518800D39EE1 /* ModifierTests.swift */; };
 		4C88353E1C82530F00F70419 /* LoggerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C1BBA6A1A6C518800D39EE1 /* LoggerTests.swift */; };
-		4CA33F341B7556FC0047C307 /* Modifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4CA86F641AEC465E005E6475 /* Modifier.swift */; };
+		4CA33F341B7556FC0047C307 /* LogMessageModifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4CA86F641AEC465E005E6475 /* LogMessageModifier.swift */; };
 		4CA33F351B7556FC0047C307 /* Logger.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4CA86F611AEC4654005E6475 /* Logger.swift */; };
 		4CA33F361B7556FC0047C307 /* LoggerConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4CA86F5E1AEC464A005E6475 /* LoggerConfiguration.swift */; };
 		4CA33F371B7556FC0047C307 /* LogLevel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C83FB2C1AEC1959003FEA49 /* LogLevel.swift */; };
-		4CA33F381B7556FC0047C307 /* Writer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4CA86F671AEC466A005E6475 /* Writer.swift */; };
+		4CA33F381B7556FC0047C307 /* LogMessageWriter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4CA86F671AEC466A005E6475 /* LogMessageWriter.swift */; };
 		4CA33F391B7556FF0047C307 /* Willow.h in Headers */ = {isa = PBXBuildFile; fileRef = 4CA75D421A6C493800275DC5 /* Willow.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		4CA75D441A6C493800275DC5 /* Willow.h in Headers */ = {isa = PBXBuildFile; fileRef = 4CA75D421A6C493800275DC5 /* Willow.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		4CA86F5F1AEC464A005E6475 /* LoggerConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4CA86F5E1AEC464A005E6475 /* LoggerConfiguration.swift */; };
 		4CA86F601AEC464A005E6475 /* LoggerConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4CA86F5E1AEC464A005E6475 /* LoggerConfiguration.swift */; };
 		4CA86F621AEC4654005E6475 /* Logger.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4CA86F611AEC4654005E6475 /* Logger.swift */; };
 		4CA86F631AEC4654005E6475 /* Logger.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4CA86F611AEC4654005E6475 /* Logger.swift */; };
-		4CA86F651AEC465E005E6475 /* Modifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4CA86F641AEC465E005E6475 /* Modifier.swift */; };
-		4CA86F661AEC465E005E6475 /* Modifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4CA86F641AEC465E005E6475 /* Modifier.swift */; };
-		4CA86F681AEC466A005E6475 /* Writer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4CA86F671AEC466A005E6475 /* Writer.swift */; };
-		4CA86F691AEC466A005E6475 /* Writer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4CA86F671AEC466A005E6475 /* Writer.swift */; };
+		4CA86F651AEC465E005E6475 /* LogMessageModifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4CA86F641AEC465E005E6475 /* LogMessageModifier.swift */; };
+		4CA86F661AEC465E005E6475 /* LogMessageModifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4CA86F641AEC465E005E6475 /* LogMessageModifier.swift */; };
+		4CA86F681AEC466A005E6475 /* LogMessageWriter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4CA86F671AEC466A005E6475 /* LogMessageWriter.swift */; };
+		4CA86F691AEC466A005E6475 /* LogMessageWriter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4CA86F671AEC466A005E6475 /* LogMessageWriter.swift */; };
 		4CBE850E1AEA2F3D006A1205 /* LogLevelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4CBE850B1AEA2EFA006A1205 /* LogLevelTests.swift */; };
 		4CBE850F1AEA2F3E006A1205 /* LogLevelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4CBE850B1AEA2EFA006A1205 /* LogLevelTests.swift */; };
 		4CC837781A6E347700B31851 /* ModifierTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C1BBA691A6C518800D39EE1 /* ModifierTests.swift */; };
@@ -91,8 +91,8 @@
 		4CA75D4B1A6C498300275DC5 /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = Info.plist; path = Tests/Info.plist; sourceTree = SOURCE_ROOT; };
 		4CA86F5E1AEC464A005E6475 /* LoggerConfiguration.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LoggerConfiguration.swift; sourceTree = "<group>"; };
 		4CA86F611AEC4654005E6475 /* Logger.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Logger.swift; sourceTree = "<group>"; };
-		4CA86F641AEC465E005E6475 /* Modifier.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Modifier.swift; sourceTree = "<group>"; };
-		4CA86F671AEC466A005E6475 /* Writer.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Writer.swift; sourceTree = "<group>"; };
+		4CA86F641AEC465E005E6475 /* LogMessageModifier.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LogMessageModifier.swift; sourceTree = "<group>"; };
+		4CA86F671AEC466A005E6475 /* LogMessageWriter.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LogMessageWriter.swift; sourceTree = "<group>"; };
 		4CBE850B1AEA2EFA006A1205 /* LogLevelTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LogLevelTests.swift; sourceTree = "<group>"; };
 		4CF89C8B1A6E2F60001BFDE1 /* Willow.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Willow.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		4CF89C951A6E2F60001BFDE1 /* WillowTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = WillowTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -163,8 +163,8 @@
 				4CA86F611AEC4654005E6475 /* Logger.swift */,
 				4CA86F5E1AEC464A005E6475 /* LoggerConfiguration.swift */,
 				4C83FB2C1AEC1959003FEA49 /* LogLevel.swift */,
-				4CA86F641AEC465E005E6475 /* Modifier.swift */,
-				4CA86F671AEC466A005E6475 /* Writer.swift */,
+				4CA86F641AEC465E005E6475 /* LogMessageModifier.swift */,
+				4CA86F671AEC466A005E6475 /* LogMessageWriter.swift */,
 				4CA75D451A6C493F00275DC5 /* Supporting Files */,
 			);
 			path = Source;
@@ -504,8 +504,8 @@
 			buildActionMask = 2147483647;
 			files = (
 				4C8835381C82530300F70419 /* LoggerConfiguration.swift in Sources */,
-				4C88353A1C82530300F70419 /* Writer.swift in Sources */,
-				4C8835361C82530300F70419 /* Modifier.swift in Sources */,
+				4C88353A1C82530300F70419 /* LogMessageWriter.swift in Sources */,
+				4C8835361C82530300F70419 /* LogMessageModifier.swift in Sources */,
 				4C8835371C82530300F70419 /* Logger.swift in Sources */,
 				4C8835391C82530300F70419 /* LogLevel.swift in Sources */,
 			);
@@ -528,8 +528,8 @@
 			buildActionMask = 2147483647;
 			files = (
 				4CA33F361B7556FC0047C307 /* LoggerConfiguration.swift in Sources */,
-				4CA33F381B7556FC0047C307 /* Writer.swift in Sources */,
-				4CA33F341B7556FC0047C307 /* Modifier.swift in Sources */,
+				4CA33F381B7556FC0047C307 /* LogMessageWriter.swift in Sources */,
+				4CA33F341B7556FC0047C307 /* LogMessageModifier.swift in Sources */,
 				4CA33F351B7556FC0047C307 /* Logger.swift in Sources */,
 				4CA33F371B7556FC0047C307 /* LogLevel.swift in Sources */,
 			);
@@ -539,9 +539,9 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				4CA86F691AEC466A005E6475 /* Writer.swift in Sources */,
+				4CA86F691AEC466A005E6475 /* LogMessageWriter.swift in Sources */,
 				4CA86F601AEC464A005E6475 /* LoggerConfiguration.swift in Sources */,
-				4CA86F661AEC465E005E6475 /* Modifier.swift in Sources */,
+				4CA86F661AEC465E005E6475 /* LogMessageModifier.swift in Sources */,
 				4C83FB2E1AEC1959003FEA49 /* LogLevel.swift in Sources */,
 				4CA86F631AEC4654005E6475 /* Logger.swift in Sources */,
 			);
@@ -563,9 +563,9 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				4CA86F681AEC466A005E6475 /* Writer.swift in Sources */,
+				4CA86F681AEC466A005E6475 /* LogMessageWriter.swift in Sources */,
 				4CA86F5F1AEC464A005E6475 /* LoggerConfiguration.swift in Sources */,
-				4CA86F651AEC465E005E6475 /* Modifier.swift in Sources */,
+				4CA86F651AEC465E005E6475 /* LogMessageModifier.swift in Sources */,
 				4C83FB2D1AEC1959003FEA49 /* LogLevel.swift in Sources */,
 				4CA86F621AEC4654005E6475 /* Logger.swift in Sources */,
 			);


### PR DESCRIPTION
This PR refactors the `Writer` and `Modifier` protocols to include a `LogMessage` prefix. There are two main reasons for these changes. 
1. We wanted to be more explicit with the protocol names to make their intent more clear. The previous names were so vague that they didn't really express intent clearly. 
2. We all agreed that `Formatter` was better than `Modifier`, but that `LogMessageModifier` was much better than `Formatter`. We also agreed that `LogMessageModifier` was much better than `Willow.Formatter` everywhere. In the end, we decided that additional verbosity to avoid conflicting with Foundation APIs was probably the best decision.
