### PR TITLE
Xcode 8 Beta 6 Support

### DIFF
--- a/Example/Frameworks/Database/Logger.swift
+++ b/Example/Frameworks/Database/Logger.swift
@@ -34,11 +34,11 @@ extension LogLevel {
 // MARK:
 
 extension Logger {
-    func sql(_ message: @autoclosure(escaping) () -> String) {
+    func sql(_ message: @autoclosure @escaping () -> String) {
         logMessage(message, with: .sql)
     }
 
-    func sql(_ message: () -> String) {
+    func sql(_ message: @escaping () -> String) {
         logMessage(message, with: .sql)
     }
 }
@@ -79,7 +79,7 @@ public var log: Logger! = {
         .error: [prefixModifier, timestampModifier, errorColorModifier]
     ]
 
-    let queue = DispatchQueue(label: "com.nike.database.logger.queue", attributes: [.serial, .qosUtility])
+    let queue = DispatchQueue(label: "com.nike.database.logger.queue", qos: .utility)
     let configuration = LoggerConfiguration(modifiers: modifiers, executionMethod: .Asynchronous(queue: queue))
 
     return Logger(configuration: configuration)

--- a/Example/Frameworks/Network/Logger.swift
+++ b/Example/Frameworks/Network/Logger.swift
@@ -57,7 +57,7 @@ public var log: Logger = {
         .error: [prefixModifier, timestampModifier, errorColorModifier]
     ]
 
-    let queue = DispatchQueue(label: "com.nike.network.logger.queue", attributes: [.serial, .qosUtility])
+    let queue = DispatchQueue(label: "com.nike.network.logger.queue", qos: .utility)
     let configuration = LoggerConfiguration(modifiers: modifiers, executionMethod: .Asynchronous(queue: queue))
 
     return Logger(configuration: configuration)

--- a/Example/iOS Example/AppDelegate.swift
+++ b/Example/iOS Example/AppDelegate.swift
@@ -26,12 +26,18 @@ import UIKit
 
 @UIApplicationMain
 class AppDelegate: UIResponder, UIApplicationDelegate {
+
+    // MARK: - Properties
+
     var window: UIWindow?
 
-    // MARK: App State
+    // MARK: - App State
 
-    func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [NSObject: AnyObject]?) -> Bool {
-
+    func application(
+        _ application: UIApplication,
+        didFinishLaunchingWithOptions launchOptions: [UIApplicationLaunchOptionsKey: Any]?)
+        -> Bool
+    {
         // If you want to use colored logging, you will need to have the XcodeColors plugin installed from Alcatraz
         // - XcodeColors: https://github.com/robbiehanson/XcodeColors
         // - Alcatraz: http://alcatraz.io/
@@ -39,9 +45,9 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         WillowConfiguration.configure(coloredOutputEnabled: true, asynchronous: false)
 
         window = {
-            let window = UIWindow(frame: UIScreen.main().bounds)
+            let window = UIWindow(frame: UIScreen.main.bounds)
             window.rootViewController = UINavigationController(rootViewController: ViewController())
-            window.backgroundColor = UIColor.white()
+            window.backgroundColor = UIColor.white
             window.makeKeyAndVisible()
 
             return window

--- a/Example/iOS Example/ViewController.swift
+++ b/Example/iOS Example/ViewController.swift
@@ -43,9 +43,9 @@ class ViewController: UIViewController {
 
     // MARK: Properties
 
-    private static let CellIdentifier = "CellID"
-    private var sections: [Section] = []
-    private var tableView: UITableView!
+    fileprivate static let CellIdentifier = "CellID"
+    fileprivate var sections: [Section] = []
+    fileprivate var tableView: UITableView!
 
     // MARK: View Lifecycle
 
@@ -67,7 +67,7 @@ class ViewController: UIViewController {
     // MARK: Private - Setup
 
     private func setUpInstanceProperties() {
-        view.backgroundColor = UIColor.white()
+        view.backgroundColor = UIColor.white
         title = "Willow"
     }
 
@@ -159,7 +159,7 @@ class ViewController: UIViewController {
                         title: "Log App Messages In Parallel",
                         action: {
                             let range = 1...10
-                            let queue = DispatchQueue.global(attributes: .qosDefault)
+                            let queue = DispatchQueue.global()
 
                             for _ in range {
                                 queue.async {
@@ -188,7 +188,7 @@ class ViewController: UIViewController {
                         title: "Log Messages From Multiple Frameworks",
                         action: {
                             let range = 1...4
-                            let queue = DispatchQueue.global(attributes: .qosDefault)
+                            let queue = DispatchQueue.global()
 
                             for _ in range {
                                 queue.async {
@@ -247,8 +247,7 @@ class ViewController: UIViewController {
     }
 }
 
-// MARK:
-// MARK: UITableViewDataSource
+// MARK: - UITableViewDataSource
 
 extension ViewController: UITableViewDataSource {
     func numberOfSections(in tableView: UITableView) -> Int {
@@ -273,8 +272,7 @@ extension ViewController: UITableViewDataSource {
     }
 }
 
-// MARK:
-// MARK: UITableViewDelegate
+// MARK: - UITableViewDelegate
 
 extension ViewController: UITableViewDelegate {
     func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {

--- a/Example/iOS Example/WillowConfiguration.swift
+++ b/Example/iOS Example/WillowConfiguration.swift
@@ -71,15 +71,15 @@ struct WillowConfiguration {
         let executionMethod: LoggerConfiguration.ExecutionMethod
 
         if asynchronous {
-            executionMethod = .Synchronous(lock: RecursiveLock())
+            executionMethod = .Synchronous(lock: NSRecursiveLock())
         } else {
             executionMethod = .Asynchronous(
-                queue: DispatchQueue(label: "com.nike.example.logger", attributes: [.serial, .qosUtility])
+                queue: DispatchQueue(label: "com.nike.example.logger", qos: .utility)
             )
         }
 
         log = configureLogger(
-            foregroundColor: Color.white(),
+            foregroundColor: Color.white,
             backgroundColor: coloredOutputEnabled ? Color(red: 0.0, green: 0.7, blue: 1.0, alpha: 1.0) : nil,
             prefix: "App",
             modifierLogLevel: [.debug, .info, .event],
@@ -88,7 +88,7 @@ struct WillowConfiguration {
         )
 
         Database.log = configureLogger(
-            foregroundColor: Color.white(),
+            foregroundColor: Color.white,
             backgroundColor: Color(red: 1.0, green: 0.518, blue: 0.043, alpha: 1.0),
             prefix: "Database",
             modifierLogLevel: [.sql, .debug, .info, .event],

--- a/Source/LogLevel.swift
+++ b/Source/LogLevel.swift
@@ -76,8 +76,7 @@ public struct LogLevel: OptionSet {
     public init(rawValue: RawValue) { self.rawValue = rawValue }
 }
 
-// MARK:
-// MARK: Hashable
+// MARK: - Hashable
 
 extension LogLevel: Equatable, Hashable {
     /// Returns the hash value using the raw bitmask value of the `LogLevel`.
@@ -111,8 +110,7 @@ extension LogLevel: CustomStringConvertible {
     }
 }
 
-// MARK:
-// MARK: Equatable
+// MARK: - Equatable
 
 /// Returns whether the `lhs` and `rhs` instances are equal.
 ///

--- a/Source/LogMessageModifier.swift
+++ b/Source/LogMessageModifier.swift
@@ -38,10 +38,10 @@ public protocol LogMessageModifier {
     func modifyMessage(_ message: String, with logLevel: LogLevel) -> String
 }
 
-// MARK:
+// MARK: -
 
 /// The TimestampModifier class applies a timestamp to the beginning of the message.
-public class TimestampModifier: LogMessageModifier {
+open class TimestampModifier: LogMessageModifier {
     private let timestampFormatter: DateFormatter = {
         var formatter = DateFormatter()
         formatter.dateFormat = "yyyy-MM-dd HH:mm:ss.SSS"
@@ -59,19 +59,19 @@ public class TimestampModifier: LogMessageModifier {
     /// - parameter logLevel: The log level set for the message.
     ///
     /// - returns: A newly formatted message.
-    public func modifyMessage(_ message: String, with logLevel: LogLevel) -> String {
+    open func modifyMessage(_ message: String, with logLevel: LogLevel) -> String {
         let timestampString = timestampFormatter.string(from: Date() as Date)
         return "\(timestampString) \(message)"
     }
 }
 
-// MARK:
+// MARK: -
 
 /// The ColorModifier class takes foreground and background colors and applies them to a given message. It uses the
 /// XcodeColors plugin color formatting scheme.
 ///
 /// NOTE: These should only be used with the XcodeColors plugin.
-public class ColorModifier: LogMessageModifier {
+open class ColorModifier: LogMessageModifier {
 
     // MARK: Helper Types
 
@@ -119,7 +119,7 @@ public class ColorModifier: LogMessageModifier {
     /// - parameter message: The message to apply the color modification to.
     ///
     /// - returns: A new string with all the color modifier values added.
-    public func modifyMessage(_ message: String, with logLevel: LogLevel) -> String {
+    open func modifyMessage(_ message: String, with logLevel: LogLevel) -> String {
         return "\(foregroundText)\(backgroundText)\(message)\(ColorConstants.RESET)"
     }
 
@@ -136,7 +136,7 @@ public class ColorModifier: LogMessageModifier {
             // Since the colorspace on OSX is not guaranteed to be `deviceRGBColorSpace`, the color must be converted
             // to guarantee that the `getRed(_:green:blue:alpha:)` call will succeed.
             #if os(OSX)
-                if let rgbColor = color.usingColorSpace(NSColorSpace.deviceRGB()) {
+                if let rgbColor = color.usingColorSpace(NSColorSpace.deviceRGB) {
                     rgbColor.getRed(&redValue, green: &greenValue, blue: &blueValue, alpha: nil)
                 }
             #else

--- a/Source/LogMessageWriter.swift
+++ b/Source/LogMessageWriter.swift
@@ -31,11 +31,11 @@ public protocol LogMessageWriter {
     func writeMessage(_ message: String, logLevel: LogLevel, modifiers: [LogMessageModifier]?)
 }
 
-// MARK:
+// MARK: -
 
 /// The ConsoleWriter class runs all modifiers in the order they were created and prints the resulting message
 /// to the console.
-public class ConsoleWriter: LogMessageWriter {
+open class ConsoleWriter: LogMessageWriter {
     /// Initializes a console writer instance.
     ///
     /// - returns: A new console writer instance.
@@ -49,10 +49,10 @@ public class ConsoleWriter: LogMessageWriter {
     /// - parameter message:   The original message to write to the console.
     /// - parameter logLevel:  The log level associated with the message.
     /// - parameter modifiers: The modifier objects to run over the message before writing to the console.
-    public func writeMessage(_ message: String, logLevel: LogLevel, modifiers: [LogMessageModifier]?) {
-        var mutableMessage = message
-        modifiers?.forEach { mutableMessage = $0.modifyMessage(mutableMessage, with: logLevel) }
+    open func writeMessage(_ message: String, logLevel: LogLevel, modifiers: [LogMessageModifier]?) {
+        var message = message
+        modifiers?.forEach { message = $0.modifyMessage(message, with: logLevel) }
 
-        print(mutableMessage)
+        print(message)
     }
 }

--- a/Source/Logger.swift
+++ b/Source/Logger.swift
@@ -30,19 +30,17 @@ import Foundation
 ///
 /// Loggers can only be configured during initialization. If you need to change a logger at runtime, it is advised to
 /// create an additional logger with a custom configuration to fit your needs.
-public class Logger {
+open class Logger {
 
-    // MARK:
-    // MARK: Properties
+    // MARK: - Properties
 
     /// Controls whether to allow log messages to be sent to the writers.
-    public var enabled = true
+    open var enabled = true
 
     /// The configuration to use when determining how to log messages.
-    public let configuration: LoggerConfiguration
+    open let configuration: LoggerConfiguration
 
-    // MARK:
-    // MARK: Initialization
+    // MARK: - Initialization
 
     /// Initializes a logger instance.
     ///
@@ -54,76 +52,75 @@ public class Logger {
         self.configuration = configuration
     }
 
-    // MARK:
-    // MARK: Logging
+    // MARK: - Logging
 
     /// Writes out the given message using the logger configuration if the debug log level has an attached writer.
     ///
     /// - parameter message: An autoclosure returning the message to log.
-    public func debug(_ message: @autoclosure(escaping) () -> String) {
+    open func debug(_ message: @autoclosure @escaping () -> String) {
         logMessage(message, with: LogLevel.debug)
     }
 
     /// Writes out the given message using the logger configuration if the debug log level has an attached writer.
     ///
     /// - parameter message: A closure returning the message to log.
-    public func debug(_ message: () -> String) {
+    open func debug(_ message: @escaping () -> String) {
         logMessage(message, with: LogLevel.debug)
     }
 
     /// Writes out the given message using the logger configuration if the info log level has an attached writer.
     ///
     /// - parameter message: An autoclosure returning the message to log.
-    public func info(_ message: @autoclosure(escaping) () -> String) {
+    open func info(_ message: @autoclosure @escaping () -> String) {
         logMessage(message, with: LogLevel.info)
     }
 
     /// Writes out the given message using the logger configuration if the info log level has an attached writer.
     ///
     /// - parameter message: A closure returning the message to log.
-    public func info(_ message: () -> String) {
+    open func info(_ message: @escaping () -> String) {
         logMessage(message, with: LogLevel.info)
     }
 
     /// Writes out the given message using the logger configuration if the event log level has an attached writer.
     ///
     /// - parameter message: An autoclosure returning the message to log.
-    public func event(_ message: @autoclosure(escaping) () -> String) {
+    open func event(_ message: @autoclosure @escaping () -> String) {
         logMessage(message, with: LogLevel.event)
     }
 
     /// Writes out the given message using the logger configuration if the event log level has an attached writer.
     ///
     /// - parameter message: A closure returning the message to log.
-    public func event(_ message: () -> String) {
+    open func event(_ message: @escaping () -> String) {
         logMessage(message, with: LogLevel.event)
     }
 
     /// Writes out the given message using the logger configuration if the warn log level has an attached writer.
     ///
     /// - parameter message: An autoclosure returning the message to log.
-    public func warn(_ message: @autoclosure(escaping) () -> String) {
+    open func warn(_ message: @autoclosure @escaping () -> String) {
         logMessage(message, with: LogLevel.warn)
     }
 
     /// Writes out the given message using the logger configuration if the warn log level has an attached writer.
     ///
     /// - parameter message: A closure returning the message to log.
-    public func warn(_ message: () -> String) {
+    open func warn(_ message: @escaping () -> String) {
         logMessage(message, with: LogLevel.warn)
     }
 
     /// Writes out the given message using the logger configuration if the error log level has an attached writer.
     ///
     /// - parameter message: An autoclosure returning the message to log.
-    public func error(_ message: @autoclosure(escaping) () -> String) {
+    open func error(_ message: @autoclosure @escaping () -> String) {
         logMessage(message, with: LogLevel.error)
     }
 
     /// Writes out the given message using the logger configuration if the error log level has an attached writer.
     ///
     /// - parameter message: A closure returning the message to log.
-    public func error(_ message: () -> String) {
+    open func error(_ message: @escaping () -> String) {
         logMessage(message, with: LogLevel.error)
     }
 
@@ -131,7 +128,7 @@ public class Logger {
     ///
     /// - parameter message:      A closure returning the message to log.
     /// - parameter withLogLevel: The log level associated with the message closure.
-    public func logMessage(_ message: () -> String, with logLevel: LogLevel) {
+    open func logMessage(_ message: @escaping () -> String, with logLevel: LogLevel) {
         guard enabled else { return }
 
         switch configuration.executionMethod {
@@ -143,8 +140,7 @@ public class Logger {
         }
     }
 
-    // MARK:
-    // MARK: Private - Log Helpers
+    // MARK: - Private - Log Helpers
 
     private func logMessageIfAllowed(_ message: () -> String, with logLevel: LogLevel) {
         guard logLevelAllowed(logLevel) else { return }

--- a/Source/LoggerConfiguration.swift
+++ b/Source/LoggerConfiguration.swift
@@ -28,8 +28,7 @@ import Foundation
 /// a Logger instance.
 public struct LoggerConfiguration {
 
-    // MARK:
-    // MARK: Helper Types
+    // MARK: - Helper Types
 
     /// Defines the two types of execution methods used when logging a message.
     ///
@@ -41,12 +40,11 @@ public struct LoggerConfiguration {
     /// - Synchronous:  Logs messages synchronously once the recursive lock is available in serial order.
     /// - Asynchronous: Logs messages asynchronously on the dispatch queue in a serial order.
     public enum ExecutionMethod {
-        case Synchronous(lock: RecursiveLock)
+        case Synchronous(lock: NSRecursiveLock)
         case Asynchronous(queue: DispatchQueue)
     }
 
-    // MARK:
-    // MARK: Properties
+    // MARK: - Properties
 
     /// The dictionary of modifiers to apply to each associated log level.
     public let modifiers: [LogLevel: [LogMessageModifier]]
@@ -57,8 +55,7 @@ public struct LoggerConfiguration {
     /// The execution method used when logging a message.
     public let executionMethod: ExecutionMethod
 
-    // MARK:
-    // MARK: Initialization
+    // MARK: - Initialization
 
     /// Initializes a logger configuration instance.
     ///
@@ -71,7 +68,7 @@ public struct LoggerConfiguration {
     public init(
         modifiers: [LogLevel: [LogMessageModifier]] = [:],
         writers: [LogLevel: [LogMessageWriter]] = [.all: [ConsoleWriter()]],
-        executionMethod: ExecutionMethod = .Synchronous(lock: RecursiveLock()))
+        executionMethod: ExecutionMethod = .Synchronous(lock: NSRecursiveLock()))
     {
         func restructureDictionaryValuesPerBitBasedLogLevel<T>(_ values: [LogLevel: [T]]) -> [LogLevel: [T]] {
             var specifiedValues: [LogLevel: [T]] = [:]
@@ -97,8 +94,7 @@ public struct LoggerConfiguration {
         self.executionMethod = executionMethod
     }
 
-    // MARK:
-    // MARK: Customized Configurations
+    // MARK: - Customized Configurations
 
     /// Creates a logger configuration instance with a timestamp modifier applied to each log level.
     ///
@@ -109,7 +105,7 @@ public struct LoggerConfiguration {
     /// - returns: A fully initialized logger configuration instance.
     public static func timestampConfiguration(
         logLevel: LogLevel = .all,
-        executionMethod: ExecutionMethod = .Synchronous(lock: RecursiveLock()))
+        executionMethod: ExecutionMethod = .Synchronous(lock: NSRecursiveLock()))
         -> LoggerConfiguration
     {
         let modifiers: [LogLevel: [LogMessageModifier]] = [logLevel: [TimestampModifier()]]
@@ -127,7 +123,7 @@ public struct LoggerConfiguration {
     /// - returns: A fully initialized logger configuration instance.
     public static func coloredTimestampConfiguration(
         logLevel: LogLevel = .all,
-        executionMethod: ExecutionMethod = .Synchronous(lock: RecursiveLock()))
+        executionMethod: ExecutionMethod = .Synchronous(lock: NSRecursiveLock()))
         -> LoggerConfiguration
     {
         let purple = Color(red: 0.6, green: 0.247, blue: 1.0, alpha: 1.0)

--- a/Tests/LogLevelTests.swift
+++ b/Tests/LogLevelTests.swift
@@ -34,25 +34,24 @@ extension LogLevel {
 }
 
 extension Logger {
-    private func verbose(message: @autoclosure(escaping) () -> String) {
+    fileprivate func verbose(message: @autoclosure @escaping () -> String) {
         logMessage(message, with: LogLevel.verbose)
     }
 
-    private func verbose(message: () -> String) {
+    fileprivate func verbose(message: @escaping () -> String) {
         logMessage(message, with: LogLevel.verbose)
     }
 
-    private func summary(message: @autoclosure(escaping) () -> String) {
+    fileprivate func summary(message: @autoclosure @escaping () -> String) {
         logMessage(message, with: LogLevel.summary)
     }
 
-    private func summary(message: () -> String) {
+    fileprivate func summary(message: @escaping () -> String) {
         logMessage(message, with: LogLevel.summary)
     }
 }
 
-// MARK:
-// MARK: Helper Test Classes
+// MARK: - Helper Test Classes
 
 class TestWriter: LogMessageWriter {
     private(set) var actualNumberOfWrites: Int = 0
@@ -64,8 +63,7 @@ class TestWriter: LogMessageWriter {
     }
 }
 
-// MARK:
-// MARK: Test Cases
+// MARK: - Test Cases
 
 class LogLevelTestCase: XCTestCase {
 
@@ -159,7 +157,7 @@ class LogLevelTestCase: XCTestCase {
     }
 }
 
-// MARK:
+// MARK: -
 
 class CustomLogLevelTestCase: XCTestCase {
 

--- a/Tests/LoggerTests.swift
+++ b/Tests/LoggerTests.swift
@@ -53,11 +53,11 @@ class SynchronousTestWriter: LogMessageWriter {
     }
 }
 
-// MARK:
+// MARK: -
 
 class AsynchronousTestWriter: SynchronousTestWriter {
     let expectation: XCTestExpectation
-    private let expectedNumberOfWrites: Int
+    let expectedNumberOfWrites: Int
 
     init(expectation: XCTestExpectation, expectedNumberOfWrites: Int) {
         self.expectation = expectation
@@ -73,7 +73,7 @@ class AsynchronousTestWriter: SynchronousTestWriter {
     }
 }
 
-// MARK:
+// MARK: -
 
 class PrefixModifier: LogMessageModifier {
     func modifyMessage(_ message: String, with: LogLevel) -> String {
@@ -81,8 +81,7 @@ class PrefixModifier: LogMessageModifier {
     }
 }
 
-// MARK:
-// MARK: Base Test Cases
+// MARK: - Base Test Cases
 
 class SynchronousLoggerTestCase: XCTestCase {
     var message = "Test Message"
@@ -113,7 +112,7 @@ class SynchronousLoggerTestCase: XCTestCase {
     }
 }
 
-// MARK:
+// MARK: -
 
 class AsynchronousLoggerTestCase: SynchronousLoggerTestCase {
     func logger(
@@ -123,7 +122,7 @@ class AsynchronousLoggerTestCase: SynchronousLoggerTestCase {
     {
         let expectation = self.expectation(description: "Test writer should receive expected number of writes")
         let writer = AsynchronousTestWriter(expectation: expectation, expectedNumberOfWrites: expectedNumberOfWrites)
-        let queue = DispatchQueue(label: "async-logger-test-queue", attributes: [.serial, .qosUtility])
+        let queue = DispatchQueue(label: "async-logger-test-queue", qos: .utility)
 
         let configuration = LoggerConfiguration(
             modifiers: modifiers,
@@ -137,8 +136,7 @@ class AsynchronousLoggerTestCase: SynchronousLoggerTestCase {
     }
 }
 
-// MARK:
-// MARK: Tests
+// MARK: - Tests
 
 class SynchronousLoggerLogLevelTestCase: SynchronousLoggerTestCase {
     func testThatItLogsAsExpectedWithOffLogLevel() {
@@ -372,7 +370,7 @@ class SynchronousLoggerLogLevelTestCase: SynchronousLoggerTestCase {
     }
 }
 
-// MARK:
+// MARK: -
 
 class AsynchronousLoggerLogLevelTestCase: AsynchronousLoggerTestCase {
     func testThatItLogsAsExpectedWithOffLogLevel() {
@@ -390,7 +388,7 @@ class AsynchronousLoggerLogLevelTestCase: AsynchronousLoggerTestCase {
         // very difficult to fullfill the expectation. For now, we are using a dispatch_after that fires
         // slightly before the timeout to fullfill the expectation.
 
-        DispatchQueue.main.after(when: .now() + 0.1) {
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
             writer.expectation.fulfill()
         }
 
@@ -540,7 +538,7 @@ class AsynchronousLoggerLogLevelTestCase: AsynchronousLoggerTestCase {
     }
 }
 
-// MARK:
+// MARK: -
 
 class SynchronousLoggerEnabledTestCase: SynchronousLoggerTestCase {
     func testThatItLogsAllLogLevelsWhenEnabled() {
@@ -576,7 +574,7 @@ class SynchronousLoggerEnabledTestCase: SynchronousLoggerTestCase {
     }
 }
 
-// MARK:
+// MARK: -
 
 class SynchronousLoggerColorModifierTestCase: SynchronousLoggerTestCase {
     func testThatItAppliesCorrectColorModifierToDebugLogLevel() {
@@ -710,7 +708,7 @@ class SynchronousLoggerColorModifierTestCase: SynchronousLoggerTestCase {
     }
 }
 
-// MARK:
+// MARK: -
 
 class SynchronousLoggerMultiModifierTestCase: SynchronousLoggerTestCase {
     func testThatItLogsOutputAsExpectedWithMultipleModifiers() {
@@ -763,7 +761,7 @@ class SynchronousLoggerMultiModifierTestCase: SynchronousLoggerTestCase {
     }
 }
 
-// MARK:
+// MARK: -
 
 class SynchronousLoggerMultiWriterTestCase: SynchronousLoggerTestCase {
     func testThatItLogsOutputAsExpectedWithMultipleWriters() {

--- a/Tests/ModifierTests.swift
+++ b/Tests/ModifierTests.swift
@@ -52,7 +52,7 @@ class TimestampModifierTestCase: XCTestCase {
     }
 }
 
-// MARK:
+// MARK: -
 
 class ColorModifierTestCase: XCTestCase {
 

--- a/Willow.xcodeproj/project.pbxproj
+++ b/Willow.xcodeproj/project.pbxproj
@@ -607,6 +607,7 @@
 		4C88352F1C82506600F70419 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
 				DEBUG_INFORMATION_FORMAT = dwarf;
 				DEFINES_MODULE = YES;
 				DYLIB_COMPATIBILITY_VERSION = 1;
@@ -627,6 +628,7 @@
 		4C8835301C82506600F70419 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
 				COPY_PHASE_STRIP = NO;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				DEFINES_MODULE = YES;
@@ -679,6 +681,7 @@
 		4CA33F321B7556D60047C307 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
 				DEBUG_INFORMATION_FORMAT = dwarf;
 				DEFINES_MODULE = YES;
 				DYLIB_COMPATIBILITY_VERSION = 1;
@@ -699,6 +702,7 @@
 		4CA33F331B7556D60047C307 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
 				COPY_PHASE_STRIP = NO;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				DEFINES_MODULE = YES;
@@ -816,8 +820,10 @@
 				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
 				CLANG_WARN_EMPTY_BODY = YES;
 				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
 				CLANG_WARN_INT_CONVERSION = YES;
 				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
 				CLANG_WARN_UNREACHABLE_CODE = YES;
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
@@ -870,8 +876,10 @@
 				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
 				CLANG_WARN_EMPTY_BODY = YES;
 				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
 				CLANG_WARN_INT_CONVERSION = YES;
 				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
 				CLANG_WARN_UNREACHABLE_CODE = YES;
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
@@ -907,7 +915,7 @@
 			buildSettings = {
 				BITCODE_GENERATION_MODE = marker;
 				CLANG_ENABLE_MODULES = YES;
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
 				DEFINES_MODULE = YES;
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
@@ -928,7 +936,7 @@
 			buildSettings = {
 				BITCODE_GENERATION_MODE = bitcode;
 				CLANG_ENABLE_MODULES = YES;
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
 				DEFINES_MODULE = YES;
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;


### PR DESCRIPTION
This PR updates the project and source code to compile against Xcode 8 beta 6. There are no really crazy changes in this PR. The most common changes include:
- Declaring async closures as `@escaping`
- DispatchQueue creation now uses the updated `qos` initializers
- `RecursiveLock` has gone back to `NSRecursiveLock`
- Colors are now static properties instead of methods
- Switched to `open` from `public` where applicable
- MARKs are no longer doubled up since jumpbar bug has been fixed

All the tests are passing on all platforms and the example app compiles and runs.
