### PR TITLE
Feature - OSLogWriter

### DIFF
--- a/README.md
+++ b/README.md
@@ -353,6 +353,22 @@ public class ConsoleWriter: LogMessageWriter {
 }
 ```
 
+#### OSLog
+
+The `OSLogWriter` class allows you to use the `os_log` APIs within the Willow system. In order to use it, all you need to do is to create the `Writer` instance and add it to the `LoggerConfiguration`.
+
+```swift
+let writer = OSLogWriter(subsystem: "com.nike.willow.example", category: "testing")
+let writers: [LogLevel: LogMessageWriter] = [.all: [writer]]
+
+let configuration = LoggerConfiguration(writers: writers)
+let log = Logger(configuration: configuration)
+
+log.debug("Hello world...coming to your from the os_log APIs!")
+```
+
+> It is important to note that this class is only available on iOS 10.0+, tvOS 10.0+ and watchOS 3.0+. It is NOT currently supported on macOS due to missing implementation in the Xcode 6 beta.
+
 #### Multiple Writers
 
 So what about logging to both a file and the console at the same time? No problem. You can pass multiple `LogMessageWriter` objects into the `Logger` initializer. The `Logger` will execute each `LogMessageWriter` in the order it was passed in. For example, let's create a `FileWriter` and combine that with our `ConsoleWriter`.

--- a/Tests/WriterTests.swift
+++ b/Tests/WriterTests.swift
@@ -23,6 +23,7 @@
 //
 
 import Foundation
+import os
 import Willow
 import XCTest
 
@@ -51,3 +52,39 @@ class ConsoleWriterTestCase: XCTestCase {
         writer.writeMessage(message, logLevel: logLevel, modifiers: [TimestampModifier()])
     }
 }
+
+// MARK: -
+
+#if !os(macOS)
+
+@available(iOS 10.0, OSX 10.12, tvOS 10.0, watchOS 3.0, *)
+class OSLogWriterTestCase: XCTestCase {
+    let subsystem = "com.nike.willow.test"
+    let category = "os-log-writer"
+
+    func testThatOSLogWriterCanBeInitializedAndDeinitialized() {
+        // Given
+        let message = "Test Message"
+        let logLevel: LogLevel = .all
+        var writer: OSLogWriter? = OSLogWriter(subsystem: subsystem, category: category)
+
+        // When, Then
+        writer?.writeMessage(message, logLevel: logLevel, modifiers: [])
+        writer = nil
+
+        // Then
+        XCTAssertNil(writer)
+    }
+
+    func testThatOSLogWriterCanWriteMessageUsingOSLog() {
+        // Given
+        let message = "Test Message"
+        let logLevel: LogLevel = .all
+        let writer = OSLogWriter(subsystem: subsystem, category: category)
+
+        // When, Then
+        writer.writeMessage(message, logLevel: logLevel, modifiers: [TimestampModifier()])
+    }
+}
+
+#endif

--- a/Willow.xcodeproj/xcshareddata/xcschemes/Willow OSX.xcscheme
+++ b/Willow.xcodeproj/xcshareddata/xcschemes/Willow OSX.xcscheme
@@ -40,8 +40,7 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      shouldUseLaunchSchemeArgsEnv = "YES"
-      codeCoverageEnabled = "YES">
+      shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
          <TestableReference
             skipped = "NO">

--- a/Willow.xcodeproj/xcshareddata/xcschemes/Willow iOS.xcscheme
+++ b/Willow.xcodeproj/xcshareddata/xcschemes/Willow iOS.xcscheme
@@ -40,8 +40,7 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      shouldUseLaunchSchemeArgsEnv = "YES"
-      codeCoverageEnabled = "YES">
+      shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
          <TestableReference
             skipped = "NO">

--- a/Willow.xcodeproj/xcshareddata/xcschemes/Willow tvOS.xcscheme
+++ b/Willow.xcodeproj/xcshareddata/xcschemes/Willow tvOS.xcscheme
@@ -40,8 +40,7 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      shouldUseLaunchSchemeArgsEnv = "YES"
-      codeCoverageEnabled = "YES">
+      shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
          <TestableReference
             skipped = "NO">

--- a/Willow.xcodeproj/xcshareddata/xcschemes/Willow watchOS.xcscheme
+++ b/Willow.xcodeproj/xcshareddata/xcschemes/Willow watchOS.xcscheme
@@ -26,8 +26,7 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      shouldUseLaunchSchemeArgsEnv = "YES"
-      codeCoverageEnabled = "YES">
+      shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
       </Testables>
       <AdditionalOptions>


### PR DESCRIPTION
This PR adds the ability to use the new `os_log` APIs directly within Willow by wrapping them in a custom `LogMessageWriter` class called `OSLogWriter`. I also added tests and documentation to the README.

> Please note that this is currently NOT supported on `macOS` due to an incomplete implementation on that platform.
