### PR TITLE
Feature - NSLog and Print ConsoleWriter

### DIFF
--- a/Source/LogMessageWriter.swift
+++ b/Source/LogMessageWriter.swift
@@ -37,10 +37,27 @@ public protocol LogMessageWriter {
 /// The ConsoleWriter class runs all modifiers in the order they were created and prints the resulting message
 /// to the console.
 open class ConsoleWriter: LogMessageWriter {
+    /// Used to define whether to use the print or NSLog functions when logging to the console.
+    ///
+    /// During development, it is recommended to use the `.print` case. When deploying to production, the `.nslog`
+    /// case should be used.
+    ///
+    /// - print: The Swift `print` function that is faster, not thread safe and doesn't write to the device console.
+    /// - nslog: The Objective-C `NSLog` function that is slower, thread safe and writes to the device console.
+    public enum Method {
+        case print, nslog
+    }
+
+    private let method: Method
+
     /// Initializes a console writer instance.
     ///
+    /// - parameter method: The method to use when logging to the console. Defaults to `.print`.
+    ///
     /// - returns: A new console writer instance.
-    public init() {}
+    public init(method: Method = .print) {
+        self.method = method
+    }
 
     /// Writes the message to the console using the global `print` function.
     ///
@@ -54,7 +71,12 @@ open class ConsoleWriter: LogMessageWriter {
         var message = message
         modifiers?.forEach { message = $0.modifyMessage(message, with: logLevel) }
 
-        print(message)
+        switch method {
+        case .print:
+            print(message)
+        case .nslog:
+            NSLog("%@", message)
+        }
     }
 }
 

--- a/Source/LogMessageWriter.swift
+++ b/Source/LogMessageWriter.swift
@@ -39,11 +39,12 @@ public protocol LogMessageWriter {
 open class ConsoleWriter: LogMessageWriter {
     /// Used to define whether to use the print or NSLog functions when logging to the console.
     ///
-    /// During development, it is recommended to use the `.print` case. When deploying to production, the `.nslog`
-    /// case should be used.
+    /// During development, it is recommendeded to use the `.print` case. When deploying to production, the `.nslog`
+    /// case should be used instead. The main reason for this is that the `print` method does not log to the device
+    /// console where as the `NSLog` method does.
     ///
-    /// - print: The Swift `print` function that is faster, not thread safe and doesn't write to the device console.
-    /// - nslog: The Objective-C `NSLog` function that is slower, thread safe and writes to the device console.
+    /// - print: Backed by the Swift `print` function.
+    /// - nslog: Backed by the Objective-C `NSLog` function.
     public enum Method {
         case print, nslog
     }

--- a/Tests/WriterTests.swift
+++ b/Tests/WriterTests.swift
@@ -42,11 +42,21 @@ class ConsoleWriterTestCase: XCTestCase {
         XCTAssertNil(writer)
     }
 
-    func testThatConsoleWriterCanWriteMessageToConsole() {
+    func testThatConsoleWriterCanWriteMessageToConsoleWithPrint() {
         // Given
         let message = "Test Message"
         let logLevel: LogLevel = .all
-        let writer = ConsoleWriter()
+        let writer = ConsoleWriter(method: .print)
+
+        // When, Then
+        writer.writeMessage(message, logLevel: logLevel, modifiers: [TimestampModifier()])
+    }
+
+    func testThatConsoleWriterCanWriteMessageToConsoleWithNSLog() {
+        // Given
+        let message = "Test Message"
+        let logLevel: LogLevel = .all
+        let writer = ConsoleWriter(method: .nslog)
 
         // When, Then
         writer.writeMessage(message, logLevel: logLevel, modifiers: [TimestampModifier()])


### PR DESCRIPTION
This PR adds a `Method` enum to the `ConsoleWriter` class to allow you to select whether to use `print` or `NSLog` internally. The differences as to using one vs. the other is called out in the enum docstring.

The reason to switch between these is that you want to use either the `os_log` APIs or `NSLog` when running on a device. Otherwise, none of the log messages will appear in the device console.
