### PR TITLE
Release - Prepping Willow 3.0.0 Release

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -49,8 +49,7 @@ script:
       xcodebuild -workspace "$WORKSPACE" -scheme "$EXAMPLE_SCHEME" -sdk "$SDK" -destination "$DESTINATION" -configuration Release ONLY_ACTIVE_ARCH=NO build | xcpretty -c; 
     fi
 
-  # Temporarily disabling pod linting per beta issue: https://github.com/CocoaPods/CocoaPods/issues/5598#issuecomment-232943917
-  # # Run `pod lib lint` if specified
-  # - if [ $POD_LINT == "YES" ]; then
-  #     pod lib lint --private;
-  #   fi
+  # Run `pod lib lint` if specified
+  - if [ $POD_LINT == "YES" ]; then
+      pod lib lint --private;
+    fi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 `Willow` adheres to [Semantic Versioning](http://semver.org/).
 
+#### 3.x Releases
+
+- `3.0.x` Releases - [3.0.0](#300)
+
 #### 2.x Releases
 
 - `2.0.x` Releases - [2.0.0](#200)
@@ -12,6 +16,51 @@ All notable changes to this project will be documented in this file.
 - `1.2.x` Releases - [1.2.0](#120)
 - `1.1.x` Releases - [1.1.0](#110)
 - `1.0.x` Releases - [1.0.0](#100)
+
+---
+
+## [3.0.0](https://github.com/Nike-Inc/Willow/releases/tag/3.0.0)
+
+Released on 2017-01-13. All issues associated with this milestone can be found using this
+[filter](https://github.com/Nike-Inc/Willow/milestone/4?closed=1).
+
+#### Added
+
+- A new `.swift-version` file for CocoaPods pointed at Swift 3.0.
+  - Added by [Christian Noon](https://github.com/cnoon).
+- A migration guide for the Willow 3.0 release.
+  - Added by [Christian Noon](https://github.com/cnoon) in Pull Request
+  [#21](https://github.com/Nike-Inc/Willow/pull/21).
+- Support for `OSLogWriter` on macOS 10.12+ by removing preprocessor guards.
+  - Added by [Silvan Mosberger](https://github.com/Infinisil) in Pull Request
+  [#19](https://github.com/Nike-Inc/Willow/pull/19).
+
+#### Updated
+
+- The Travis-CI YAML file to Xcode 8.2 and the latest SDKs and destinations.
+  - Added by [Silvan Mosberger](https://github.com/Infinisil) in Pull Request
+  [#19](https://github.com/Nike-Inc/Willow/pull/19).
+- The Travis-CI YAML file by re-enabling `pod lib lint` since lint issue is resolved.
+  - Updated by [Christian Noon](https://github.com/cnoon) in Pull Request
+  [#21](https://github.com/Nike-Inc/Willow/pull/21).
+- The Xcode projects to Xcode 8.2 and disabled automatic signing on frameworks.
+  - Updated by [Christian Noon](https://github.com/cnoon) in Pull Request
+  [#21](https://github.com/Nike-Inc/Willow/pull/21).
+- Instances of `OSX` with `macOS` including the framework and target names.
+  - Updated by [Christian Noon](https://github.com/cnoon) in Pull Request
+  [#21](https://github.com/Nike-Inc/Willow/pull/21).
+- `ExecutionMethod` enum cases to be lowercased to match Swift API Design Guidelines.
+  - Updated by [Christian Noon](https://github.com/cnoon) in Pull Request
+  [#21](https://github.com/Nike-Inc/Willow/pull/21).
+
+#### Fixed
+
+- Crash in WriterTests on iOS and tvOS 9 where `os_log` APIs are not available.
+  - Fixed by [Christian Noon](https://github.com/cnoon) in Pull Request
+  [#21](https://github.com/Nike-Inc/Willow/pull/21).
+- Compiler warnings in the example app around private and fileprivate ACLs.
+  - Fixed by [Christian Noon](https://github.com/cnoon) in Pull Request
+  [#21](https://github.com/Nike-Inc/Willow/pull/21).
 
 ---
 

--- a/Documentation/Willow 3.0 Migration Guide.md
+++ b/Documentation/Willow 3.0 Migration Guide.md
@@ -1,0 +1,30 @@
+# Willow 3.0 Migration Guide
+
+Willow 3.0 is the latest major release of Willow, a powerful, yet lightweight logging library for iOS, macOS, tvOS and watchOS written in Swift. As a major release, following Semantic Versioning conventions, 3.0 introduces several API-breaking changes that one should be aware of.
+
+This guide is provided in order to ease the transition of existing applications using Willow 2.x to the latest APIs.
+
+## Requirements
+
+Willow 3.0 officially supports iOS 9.0+, macOS 10.11+, tvOS 9.0+, watchOS 2.0+, Xcode 8.2+ and Swift 3.0+. If you'd like to use Willow in a project targeting iOS 8 and Swift 2.3, use the latest tagged 1.x release.
+
+---
+
+## Breaking API Changes
+
+Willow 3.0 contains only two breaking API changes that are very minor, but needed to be corrected. Most of your Willow code will be able to remain the same.
+
+### ExecutionMethod
+
+The `ExecutionMethod` cases have been refactored to be lowercased to match the Swift API Design Guidelines. Sadly this was missed in the port of Willow 2.0.
+
+```swift
+public struct LoggerConfiguration
+    public enum ExecutionMethod {
+        case synchronous(lock: NSRecursiveLock)
+        case asynchronous(queue: DispatchQueue)
+    }
+}
+```
+
+This change should be simple to make in your Willow code.

--- a/Example/Frameworks/Database.xcodeproj/project.pbxproj
+++ b/Example/Frameworks/Database.xcodeproj/project.pbxproj
@@ -183,11 +183,12 @@
 		4C2DC4101CDEB4F4009CA3C5 /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
-				LastUpgradeCheck = 0800;
+				LastUpgradeCheck = 0820;
 				ORGANIZATIONNAME = Nike;
 				TargetAttributes = {
 					4C2DC4181CDEB4F4009CA3C5 = {
 						CreatedOnToolsVersion = 7.3;
+						ProvisioningStyle = Manual;
 					};
 				};
 			};
@@ -311,8 +312,10 @@
 				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
 				CLANG_WARN_EMPTY_BODY = YES;
 				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
 				CLANG_WARN_INT_CONVERSION = YES;
 				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
 				CLANG_WARN_UNREACHABLE_CODE = YES;
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
@@ -364,8 +367,10 @@
 				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
 				CLANG_WARN_EMPTY_BODY = YES;
 				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
 				CLANG_WARN_INT_CONVERSION = YES;
 				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
 				CLANG_WARN_UNREACHABLE_CODE = YES;
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
@@ -400,7 +405,9 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CLANG_ENABLE_MODULES = YES;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
 				DEFINES_MODULE = YES;
+				DEVELOPMENT_TEAM = "";
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
@@ -418,7 +425,9 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CLANG_ENABLE_MODULES = YES;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
 				DEFINES_MODULE = YES;
+				DEVELOPMENT_TEAM = "";
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";

--- a/Example/Frameworks/Database/Logger.swift
+++ b/Example/Frameworks/Database/Logger.swift
@@ -31,7 +31,7 @@ extension LogLevel {
     public static let sql = LogLevel(rawValue: 0b00000000_00000000_00000001_00000000)
 }
 
-// MARK:
+// MARK: -
 
 extension Logger {
     func sql(_ message: @autoclosure @escaping () -> String) {
@@ -43,7 +43,7 @@ extension Logger {
     }
 }
 
-// MARK:
+// MARK: -
 
 /// The single `Logger` instance used throughout Database.
 public var log: Logger! = {

--- a/Example/Frameworks/Network.xcodeproj/project.pbxproj
+++ b/Example/Frameworks/Network.xcodeproj/project.pbxproj
@@ -183,11 +183,12 @@
 		4C2DC3DB1CDEB279009CA3C5 /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
-				LastUpgradeCheck = 0800;
+				LastUpgradeCheck = 0820;
 				ORGANIZATIONNAME = Nike;
 				TargetAttributes = {
 					4C2DC3E31CDEB279009CA3C5 = {
 						CreatedOnToolsVersion = 7.3;
+						ProvisioningStyle = Manual;
 					};
 				};
 			};
@@ -311,8 +312,10 @@
 				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
 				CLANG_WARN_EMPTY_BODY = YES;
 				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
 				CLANG_WARN_INT_CONVERSION = YES;
 				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
 				CLANG_WARN_UNREACHABLE_CODE = YES;
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
@@ -364,8 +367,10 @@
 				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
 				CLANG_WARN_EMPTY_BODY = YES;
 				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
 				CLANG_WARN_INT_CONVERSION = YES;
 				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
 				CLANG_WARN_UNREACHABLE_CODE = YES;
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
@@ -400,7 +405,9 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CLANG_ENABLE_MODULES = YES;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
 				DEFINES_MODULE = YES;
+				DEVELOPMENT_TEAM = "";
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
@@ -418,7 +425,9 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CLANG_ENABLE_MODULES = YES;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
 				DEFINES_MODULE = YES;
+				DEVELOPMENT_TEAM = "";
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";

--- a/Example/iOS Example.xcodeproj/project.pbxproj
+++ b/Example/iOS Example.xcodeproj/project.pbxproj
@@ -189,11 +189,12 @@
 			isa = PBXProject;
 			attributes = {
 				LastSwiftUpdateCheck = 0700;
-				LastUpgradeCheck = 0800;
+				LastUpgradeCheck = 0820;
 				ORGANIZATIONNAME = Nike;
 				TargetAttributes = {
 					4C2776A61A6C55F4007B1133 = {
 						CreatedOnToolsVersion = 6.1.1;
+						ProvisioningStyle = Automatic;
 					};
 				};
 			};
@@ -305,8 +306,10 @@
 				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
 				CLANG_WARN_EMPTY_BODY = YES;
 				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
 				CLANG_WARN_INT_CONVERSION = YES;
 				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
 				CLANG_WARN_UNREACHABLE_CODE = YES;
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
@@ -355,8 +358,10 @@
 				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
 				CLANG_WARN_EMPTY_BODY = YES;
 				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
 				CLANG_WARN_INT_CONVERSION = YES;
 				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
 				CLANG_WARN_UNREACHABLE_CODE = YES;
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
@@ -389,6 +394,8 @@
 			buildSettings = {
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				DEVELOPMENT_TEAM = "";
 				FRAMEWORK_SEARCH_PATHS = "$(inherited)";
 				INFOPLIST_FILE = "iOS Example/Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
@@ -402,6 +409,8 @@
 			buildSettings = {
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				DEVELOPMENT_TEAM = "";
 				FRAMEWORK_SEARCH_PATHS = "$(inherited)";
 				INFOPLIST_FILE = "iOS Example/Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";

--- a/Example/iOS Example.xcodeproj/xcshareddata/xcschemes/iOS Example.xcscheme
+++ b/Example/iOS Example.xcodeproj/xcshareddata/xcschemes/iOS Example.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0800"
+   LastUpgradeVersion = "0820"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Example/iOS Example/ViewController.swift
+++ b/Example/iOS Example/ViewController.swift
@@ -31,19 +31,19 @@ class ViewController: UIViewController {
 
     // MARK: Helper Types
 
-    private struct Section {
+    fileprivate struct Section {
         let title: String
         let items: [Item]
     }
 
-    private struct Item {
+    fileprivate struct Item {
         let title: String
         let action: () -> Void
     }
 
     // MARK: Properties
 
-    fileprivate static let CellIdentifier = "CellID"
+    fileprivate static let cellIdentifier = "CellID"
     fileprivate var sections: [Section] = []
     fileprivate var tableView: UITableView!
 
@@ -238,7 +238,7 @@ class ViewController: UIViewController {
             tableView.allowsSelectionDuringEditing = false
             tableView.allowsMultipleSelectionDuringEditing = false
 
-            tableView.register(UITableViewCell.self, forCellReuseIdentifier: ViewController.CellIdentifier)
+            tableView.register(UITableViewCell.self, forCellReuseIdentifier: ViewController.cellIdentifier)
 
             view.addSubview(tableView)
 
@@ -261,7 +261,7 @@ extension ViewController: UITableViewDataSource {
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
         let item = sections[indexPath.section].items[indexPath.row]
 
-        let cell = tableView.dequeueReusableCell(withIdentifier: ViewController.CellIdentifier, for: indexPath)
+        let cell = tableView.dequeueReusableCell(withIdentifier: ViewController.cellIdentifier, for: indexPath)
         cell.textLabel?.text = item.title
 
         return cell

--- a/Example/iOS Example/WillowConfiguration.swift
+++ b/Example/iOS Example/WillowConfiguration.swift
@@ -32,7 +32,7 @@ var log: Logger!
 
 struct WillowConfiguration {
 
-    // MARK: Modifiers
+    // MARK: - Modifiers
 
     private struct PrefixModifier: LogMessageModifier {
         let emoji: String
@@ -60,7 +60,7 @@ struct WillowConfiguration {
         }
     }
 
-    // MARK: Configure
+    // MARK: - Configure
 
     static func configure(
         appLogLevels: LogLevel = [.debug, .info, .event],

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ source 'https://github.com/CocoaPods/Specs.git'
 platform :ios, '10.0'
 use_frameworks!
 
-pod 'Willow', '~> 2.0'
+pod 'Willow', '~> 3.0'
 ```
 
 Then, run the following command:
@@ -104,7 +104,7 @@ brew install carthage
 To integrate Willow into your Xcode project using Carthage, specify it in your [Cartfile](https://github.com/Carthage/Carthage/blob/master/Documentation/Artifacts.md#cartfile):
 
 ```
-github "Nike-Inc/Willow" ~> 2.0
+github "Nike-Inc/Willow" ~> 3.0
 ```
 
 Run `carthage update` to build the framework and drag the built `Willow.framework` into your Xcode project.

--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ The `LoggerConfiguration` class is a container class to store all the configurat
 
 * `modifiers: [LogLevel: [LogMessageModifier]] = [:]` - The dictionary of modifiers to apply to each associated log level.
 * `writers: [LogLevel: [Writer]] = [.all: [ConsoleWriter()]` - The dictionary of writers to write to for the associated log level. Writers can be used to log output to a specific destination such as the console or to a file.
-* `executionMethod: ExecutionMethod = .Synchronous(lock: NSRecursiveLock())` - The execution method used when writing messages.
+* `executionMethod: ExecutionMethod = .synchronous(lock: NSRecursiveLock())` - The execution method used when writing messages.
 
 `LoggerConfiguration` and `Logger` objects can only be customized during initialization. If you need to change a `Logger` at runtime, it is advised to create an additional logger with a custom configuration to fit your needs. It is perfectly acceptable to have many different `Logger` instances running simutaneously.
 
@@ -221,7 +221,7 @@ Logging can greatly affect the runtime performance of your application or librar
 
 ```swift
 let queue = DispatchQueue(label: "serial.queue", qos: .utility)
-let configuration = LoggerConfiguration(executionMethod: .Asynchronous(queue: queue))
+let configuration = LoggerConfiguration(executionMethod: .asynchronous(queue: queue))
 let log = Logger(configuration: configuration)
 ```
 
@@ -440,7 +440,7 @@ let sharedQueue = DispatchQueue(label: "com.math.logger", qos: .utility)
 let writers: [LogLevel: [LogMessageWriter]] = [.all: [FileWriter(), ConsoleWriter()]]
 let configuration = LoggerConfiguration(
     writers: writers, 
-    executionMethod: .Asynchronous(queue: sharedQueue)
+    executionMethod: .asynchronous(queue: sharedQueue)
 )
 
 var log = Logger(configuration: configuration)
@@ -449,7 +449,7 @@ var log = Logger(configuration: configuration)
 let mathConfiguration = LoggerConfiguration(
     modifiers: Math.log.configuration.modifiers,
     writers: Math.log.configuration.writers,
-    executionMethod: .Asynchronous(queue: sharedQueue)
+    executionMethod: .asynchronous(queue: sharedQueue)
 )
 
 Math.log = Logger(configuration: mathConfiguration)

--- a/README.md
+++ b/README.md
@@ -47,12 +47,13 @@ Willow is a powerful, yet lightweight logging library written in Swift.
 ## Requirements
 
 - iOS 9.0+ / Mac OS X 10.11+ / tvOS 9.0+ / watchOS 2.0+
-- Xcode 8.0+
+- Xcode 8.2+
 - Swift 3.0+
 
 ## Migration Guides
 
 - [Willow 2.0 Migration Guide](https://github.com/Nike-Inc/Willow/blob/master/Documentation/Willow%202.0%20Migration%20Guide.md)
+- [Willow 3.0 Migration Guide](https://github.com/Nike-Inc/Willow/blob/master/Documentation/Willow%203.0%20Migration%20Guide.md)
 
 ## Communication
 
@@ -71,7 +72,7 @@ Willow is a powerful, yet lightweight logging library written in Swift.
 [sudo] gem install cocoapods
 ```
 
-> CocoaPods 1.0+ is required.
+> CocoaPods 1.1+ is required.
 
 To integrate Willow into your project, specify it in your [Podfile](http://guides.cocoapods.org/using/the-podfile.html):
 

--- a/Source/Info-tvOS.plist
+++ b/Source/Info-tvOS.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.0.0</string>
+	<string>3.0.0</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>

--- a/Source/Info.plist
+++ b/Source/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.0.0</string>
+	<string>3.0.0</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>

--- a/Source/LogLevel.swift
+++ b/Source/LogLevel.swift
@@ -70,9 +70,9 @@ public struct LogLevel: OptionSet {
 
     /// Creates a log level instance with the given raw value.
     ///
-    /// - parameter rawValue: The raw bitmask value for the log level.
+    /// - Parameter rawValue: The raw bitmask value for the log level.
     ///
-    /// - returns: A new log level instance.
+    /// - Returns: A new log level instance.
     public init(rawValue: RawValue) { self.rawValue = rawValue }
 }
 
@@ -83,8 +83,7 @@ extension LogLevel: Equatable, Hashable {
     public var hashValue: Int { return rawValue.hashValue }
 }
 
-// MARK:
-// MARK: CustomStringConvertible
+// MARK: - CustomStringConvertible
 
 extension LogLevel: CustomStringConvertible {
     /// Returns a `String` representation of the `LogLevel`.
@@ -114,10 +113,11 @@ extension LogLevel: CustomStringConvertible {
 
 /// Returns whether the `lhs` and `rhs` instances are equal.
 ///
-/// - parameter lhs: The left-hand side `LogLevel` instance to compare.
-/// - parameter rhs: The right-hand side `LogLevel` instance to compare.
+/// - Parameters:
+///   - lhs: The left-hand side `LogLevel` instance to compare.
+///   - rhs: The right-hand side `LogLevel` instance to compare.
 ///
-/// - returns: Whether the two instances are equal.
+/// - Returns: Whether the two instances are equal.
 public func ==(lhs: LogLevel, rhs: LogLevel) -> Bool {
     return lhs.rawValue == rhs.rawValue
 }

--- a/Source/LogMessageModifier.swift
+++ b/Source/LogMessageModifier.swift
@@ -42,15 +42,16 @@ open class TimestampModifier: LogMessageModifier {
 
     /// Initializes a `TimestampModifier` instance.
     ///
-    /// - returns: A new `TimestampModifier` instance.
+    /// - Returns: A new `TimestampModifier` instance.
     public init() {}
 
     /// Applies a timestamp to the beginning of the message.
     ///
-    /// - parameter message:  The original message to format.
-    /// - parameter logLevel: The log level set for the message.
+    /// - Parameters:
+    ///   - message:  The original message to format.
+    ///   - logLevel: The log level set for the message.
     ///
-    /// - returns: A newly formatted message.
+    /// - Returns: A newly formatted message.
     open func modifyMessage(_ message: String, with logLevel: LogLevel) -> String {
         let timestampString = timestampFormatter.string(from: Date() as Date)
         return "\(timestampString) \(message)"

--- a/Source/LogMessageWriter.swift
+++ b/Source/LogMessageWriter.swift
@@ -53,9 +53,9 @@ open class ConsoleWriter: LogMessageWriter {
 
     /// Initializes a console writer instance.
     ///
-    /// - parameter method: The method to use when logging to the console. Defaults to `.print`.
+    /// - Parameter method: The method to use when logging to the console. Defaults to `.print`.
     ///
-    /// - returns: A new console writer instance.
+    /// - Returns: A new console writer instance.
     public init(method: Method = .print) {
         self.method = method
     }
@@ -65,9 +65,10 @@ open class ConsoleWriter: LogMessageWriter {
     /// Each modifier is run over the message in the order they are provided before writing the message to
     /// the console.
     ///
-    /// - parameter message:   The original message to write to the console.
-    /// - parameter logLevel:  The log level associated with the message.
-    /// - parameter modifiers: The modifier objects to run over the message before writing to the console.
+    /// - Parameters:
+    ///   - message:   The original message to write to the console.
+    ///   - logLevel:  The log level associated with the message.
+    ///   - modifiers: The modifier objects to run over the message before writing to the console.
     open func writeMessage(_ message: String, logLevel: LogLevel, modifiers: [LogMessageModifier]?) {
         var message = message
         modifiers?.forEach { message = $0.modifyMessage(message, with: logLevel) }
@@ -91,9 +92,15 @@ open class OSLogWriter: LogMessageWriter {
     open let category: String
     private let log: OSLog
 
+    /// Creates an `OSLogWriter` instance from the specified `subsystem` and `category`.
+    ///
+    /// - Parameters:
+    ///   - subsystem: The subsystem.
+    ///   - category:  The category.
     public init(subsystem: String, category: String) {
         self.subsystem = subsystem
         self.category = category
+
         self.log = OSLog(subsystem: subsystem, category: category)
     }
 
@@ -102,9 +109,10 @@ open class OSLogWriter: LogMessageWriter {
     /// Each modifier is run over the message in the order they are provided before writing the message to
     /// the console.
     ///
-    /// - parameter message:   The original message to write to the console.
-    /// - parameter logLevel:  The log level associated with the message.
-    /// - parameter modifiers: The modifier objects to run over the message before writing to the console.
+    /// - Parameters:
+    ///   - message:   The original message to write to the console.
+    ///   - logLevel:  The log level associated with the message.
+    ///   - modifiers: The modifier objects to run over the message before writing to the console.
     open func writeMessage(_ message: String, logLevel: LogLevel, modifiers: [LogMessageModifier]?) {
         var message = message
         modifiers?.forEach { message = $0.modifyMessage(message, with: logLevel) }

--- a/Source/LogMessageWriter.swift
+++ b/Source/LogMessageWriter.swift
@@ -85,7 +85,7 @@ open class ConsoleWriter: LogMessageWriter {
 
 /// The OSLogWriter class runs all modifiers in the order they were created and passes the resulting message
 /// off to an OSLog with the specified subsystem and category.
-@available(iOS 10.0, OSX 10.12.0, tvOS 10.0, watchOS 3.0, *)
+@available(iOS 10.0, macOS 10.12.0, tvOS 10.0, watchOS 3.0, *)
 open class OSLogWriter: LogMessageWriter {
     open let subsystem: String
     open let category: String

--- a/Source/Logger.swift
+++ b/Source/Logger.swift
@@ -44,10 +44,10 @@ open class Logger {
 
     /// Initializes a logger instance.
     ///
-    /// - parameter configuration: The configuration to use when determining how to log messages. Creates a default
+    /// - Parameter configuration: The configuration to use when determining how to log messages. Creates a default
     ///                            `LoggerConfiguration()` by default.
     ///
-    /// - returns: A fully initialized logger instance.
+    /// - Returns: A fully initialized logger instance.
     public init(configuration: LoggerConfiguration = LoggerConfiguration()) {
         self.configuration = configuration
     }
@@ -56,78 +56,79 @@ open class Logger {
 
     /// Writes out the given message using the logger configuration if the debug log level has an attached writer.
     ///
-    /// - parameter message: An autoclosure returning the message to log.
+    /// - Parameter message: An autoclosure returning the message to log.
     open func debug(_ message: @autoclosure @escaping () -> String) {
         logMessage(message, with: LogLevel.debug)
     }
 
     /// Writes out the given message using the logger configuration if the debug log level has an attached writer.
     ///
-    /// - parameter message: A closure returning the message to log.
+    /// - Parameter message: A closure returning the message to log.
     open func debug(_ message: @escaping () -> String) {
         logMessage(message, with: LogLevel.debug)
     }
 
     /// Writes out the given message using the logger configuration if the info log level has an attached writer.
     ///
-    /// - parameter message: An autoclosure returning the message to log.
+    /// - Parameter message: An autoclosure returning the message to log.
     open func info(_ message: @autoclosure @escaping () -> String) {
         logMessage(message, with: LogLevel.info)
     }
 
     /// Writes out the given message using the logger configuration if the info log level has an attached writer.
     ///
-    /// - parameter message: A closure returning the message to log.
+    /// - Parameter message: A closure returning the message to log.
     open func info(_ message: @escaping () -> String) {
         logMessage(message, with: LogLevel.info)
     }
 
     /// Writes out the given message using the logger configuration if the event log level has an attached writer.
     ///
-    /// - parameter message: An autoclosure returning the message to log.
+    /// - Parameter message: An autoclosure returning the message to log.
     open func event(_ message: @autoclosure @escaping () -> String) {
         logMessage(message, with: LogLevel.event)
     }
 
     /// Writes out the given message using the logger configuration if the event log level has an attached writer.
     ///
-    /// - parameter message: A closure returning the message to log.
+    /// - Parameter message: A closure returning the message to log.
     open func event(_ message: @escaping () -> String) {
         logMessage(message, with: LogLevel.event)
     }
 
     /// Writes out the given message using the logger configuration if the warn log level has an attached writer.
     ///
-    /// - parameter message: An autoclosure returning the message to log.
+    /// - Parameter message: An autoclosure returning the message to log.
     open func warn(_ message: @autoclosure @escaping () -> String) {
         logMessage(message, with: LogLevel.warn)
     }
 
     /// Writes out the given message using the logger configuration if the warn log level has an attached writer.
     ///
-    /// - parameter message: A closure returning the message to log.
+    /// - Parameter message: A closure returning the message to log.
     open func warn(_ message: @escaping () -> String) {
         logMessage(message, with: LogLevel.warn)
     }
 
     /// Writes out the given message using the logger configuration if the error log level has an attached writer.
     ///
-    /// - parameter message: An autoclosure returning the message to log.
+    /// - Parameter message: An autoclosure returning the message to log.
     open func error(_ message: @autoclosure @escaping () -> String) {
         logMessage(message, with: LogLevel.error)
     }
 
     /// Writes out the given message using the logger configuration if the error log level has an attached writer.
     ///
-    /// - parameter message: A closure returning the message to log.
+    /// - Parameter message: A closure returning the message to log.
     open func error(_ message: @escaping () -> String) {
         logMessage(message, with: LogLevel.error)
     }
 
     /// Writes out the given message closure string with the logger configuration if the log level is allowed.
     ///
-    /// - parameter message:      A closure returning the message to log.
-    /// - parameter withLogLevel: The log level associated with the message closure.
+    /// - Parameters:
+    ///   - message:      A closure returning the message to log.
+    ///   - withLogLevel: The log level associated with the message closure.
     open func logMessage(_ message: @escaping () -> String, with logLevel: LogLevel) {
         guard enabled else { return }
 

--- a/Source/Logger.swift
+++ b/Source/Logger.swift
@@ -132,10 +132,10 @@ open class Logger {
         guard enabled else { return }
 
         switch configuration.executionMethod {
-        case .Synchronous(let lock):
+        case .synchronous(let lock):
             lock.lock() ; defer { lock.unlock() }
             logMessageIfAllowed(message, with: logLevel)
-        case .Asynchronous(let queue):
+        case .asynchronous(let queue):
             queue.async { self.logMessageIfAllowed(message, with: logLevel) }
         }
     }

--- a/Source/LoggerConfiguration.swift
+++ b/Source/LoggerConfiguration.swift
@@ -37,11 +37,11 @@ public struct LoggerConfiguration {
     /// in development, and the asynchronous method in production. This allows for easier debugging in the development
     /// environment, and better performance in production.
     ///
-    /// - Synchronous:  Logs messages synchronously once the recursive lock is available in serial order.
-    /// - Asynchronous: Logs messages asynchronously on the dispatch queue in a serial order.
+    /// - synchronous:  Logs messages synchronously once the recursive lock is available in serial order.
+    /// - asynchronous: Logs messages asynchronously on the dispatch queue in a serial order.
     public enum ExecutionMethod {
-        case Synchronous(lock: NSRecursiveLock)
-        case Asynchronous(queue: DispatchQueue)
+        case synchronous(lock: NSRecursiveLock)
+        case asynchronous(queue: DispatchQueue)
     }
 
     // MARK: - Properties
@@ -62,13 +62,13 @@ public struct LoggerConfiguration {
     /// - parameter modifiers:       The dictionary of modifiers to apply to the associated log level. `[:]` by default.
     /// - parameter writers:         The dictionary of writers to write to for the associated log level.
     ///                              `[.All: [ConsoleWriter()]` by default.
-    /// - parameter executionMethod: The execution method used when logging a message. `.Synchronous` by default.
+    ///   - executionMethod: The execution method used when logging a message. `.synchronous` by default.
     ///
     /// - returns: A fully initialized logger configuration instance.
     public init(
         modifiers: [LogLevel: [LogMessageModifier]] = [:],
         writers: [LogLevel: [LogMessageWriter]] = [.all: [ConsoleWriter()]],
-        executionMethod: ExecutionMethod = .Synchronous(lock: NSRecursiveLock()))
+        executionMethod: ExecutionMethod = .synchronous(lock: NSRecursiveLock()))
     {
         func restructureDictionaryValuesPerBitBasedLogLevel<T>(_ values: [LogLevel: [T]]) -> [LogLevel: [T]] {
             var specifiedValues: [LogLevel: [T]] = [:]
@@ -100,12 +100,12 @@ public struct LoggerConfiguration {
     ///
     /// - parameter logLevel:        The log level to apply to the default `ConsoleWriter`. `.All` by default.
     /// - parameter asynchronous:    Whether to write messages asynchronously on the given queue. `false` by default.
-    /// - parameter executionMethod: The execution method used when logging a message. `.Synchronous` by default.
+    ///   - executionMethod: The execution method used when logging a message. `.synchronous` by default.
     ///
     /// - returns: A fully initialized logger configuration instance.
     public static func timestampConfiguration(
         logLevel: LogLevel = .all,
-        executionMethod: ExecutionMethod = .Synchronous(lock: NSRecursiveLock()))
+        executionMethod: ExecutionMethod = .synchronous(lock: NSRecursiveLock()))
         -> LoggerConfiguration
     {
         let modifiers: [LogLevel: [LogMessageModifier]] = [logLevel: [TimestampModifier()]]

--- a/Source/LoggerConfiguration.swift
+++ b/Source/LoggerConfiguration.swift
@@ -59,12 +59,13 @@ public struct LoggerConfiguration {
 
     /// Initializes a logger configuration instance.
     ///
-    /// - parameter modifiers:       The dictionary of modifiers to apply to the associated log level. `[:]` by default.
-    /// - parameter writers:         The dictionary of writers to write to for the associated log level.
-    ///                              `[.All: [ConsoleWriter()]` by default.
+    /// - Parameters:
+    ///   - modifiers:       The dictionary of modifiers to apply to the associated log level. `[:]` by default.
+    ///   - writers:         The dictionary of writers to write to for the associated log level.
+    ///                      `[.All: [ConsoleWriter()]` by default.
     ///   - executionMethod: The execution method used when logging a message. `.synchronous` by default.
     ///
-    /// - returns: A fully initialized logger configuration instance.
+    /// - Returns: A fully initialized logger configuration instance.
     public init(
         modifiers: [LogLevel: [LogMessageModifier]] = [:],
         writers: [LogLevel: [LogMessageWriter]] = [.all: [ConsoleWriter()]],
@@ -98,11 +99,11 @@ public struct LoggerConfiguration {
 
     /// Creates a logger configuration instance with a timestamp modifier applied to each log level.
     ///
-    /// - parameter logLevel:        The log level to apply to the default `ConsoleWriter`. `.All` by default.
-    /// - parameter asynchronous:    Whether to write messages asynchronously on the given queue. `false` by default.
+    /// - Parameters:
+    ///   - logLevel:        The log level to apply to the default `ConsoleWriter`. `.All` by default.
     ///   - executionMethod: The execution method used when logging a message. `.synchronous` by default.
     ///
-    /// - returns: A fully initialized logger configuration instance.
+    /// - Returns: A fully initialized logger configuration instance.
     public static func timestampConfiguration(
         logLevel: LogLevel = .all,
         executionMethod: ExecutionMethod = .synchronous(lock: NSRecursiveLock()))

--- a/Tests/LoggerTests.swift
+++ b/Tests/LoggerTests.swift
@@ -119,7 +119,7 @@ class AsynchronousLoggerTestCase: SynchronousLoggerTestCase {
         let configuration = LoggerConfiguration(
             modifiers: modifiers,
             writers: [logLevel: [writer]],
-            executionMethod: .Asynchronous(queue: queue)
+            executionMethod: .asynchronous(queue: queue)
         )
 
         let logger = Logger(configuration: configuration)

--- a/Tests/LoggerTests.swift
+++ b/Tests/LoggerTests.swift
@@ -27,9 +27,9 @@ import Willow
 import XCTest
 
 #if os(iOS) || os(tvOS) || os(watchOS)
-import UIKit
+    import UIKit
 #elseif os(macOS)
-import Cocoa
+    import Cocoa
 #endif
 
 // MARK: Test Helpers

--- a/Tests/LoggerTests.swift
+++ b/Tests/LoggerTests.swift
@@ -28,7 +28,7 @@ import XCTest
 
 #if os(iOS) || os(tvOS) || os(watchOS)
 import UIKit
-#elseif os(OSX)
+#elseif os(macOS)
 import Cocoa
 #endif
 

--- a/Tests/WriterTests.swift
+++ b/Tests/WriterTests.swift
@@ -70,7 +70,7 @@ class OSLogWriterTestCase: XCTestCase {
     let category = "os-log-writer"
 
     func testThatOSLogWriterCanBeInitializedAndDeinitialized() {
-        guard #available(iOS 10.0, OSX 10.12, tvOS 10.0, *) else { return }
+        guard #available(iOS 10.0, macOS 10.12, tvOS 10.0, *) else { return }
 
         // Given
         let message = "Test Message"
@@ -86,7 +86,7 @@ class OSLogWriterTestCase: XCTestCase {
     }
 
     func testThatOSLogWriterCanWriteMessageUsingOSLog() {
-        guard #available(iOS 10.0, OSX 10.12, tvOS 10.0, *) else { return }
+        guard #available(iOS 10.0, macOS 10.12, tvOS 10.0, *) else { return }
 
         // Given
         let message = "Test Message"

--- a/Willow.podspec
+++ b/Willow.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name = 'Willow'
-  s.version = '2.0.0'
+  s.version = '3.0.0'
   s.license = 'MIT'
   s.summary = 'A powerful, yet lightweight logging library written in Swift.'
   s.homepage = 'https://github.com/Nike-Inc/Willow'

--- a/Willow.xcodeproj/project.pbxproj
+++ b/Willow.xcodeproj/project.pbxproj
@@ -317,9 +317,9 @@
 			productReference = 4CA33F2C1B7556D60047C307 /* Willow.framework */;
 			productType = "com.apple.product-type.framework";
 		};
-		4CF89C8A1A6E2F60001BFDE1 /* Willow OSX */ = {
+		4CF89C8A1A6E2F60001BFDE1 /* Willow macOS */ = {
 			isa = PBXNativeTarget;
-			buildConfigurationList = 4CF89CA21A6E2F60001BFDE1 /* Build configuration list for PBXNativeTarget "Willow OSX" */;
+			buildConfigurationList = 4CF89CA21A6E2F60001BFDE1 /* Build configuration list for PBXNativeTarget "Willow macOS" */;
 			buildPhases = (
 				4CF89C861A6E2F60001BFDE1 /* Sources */,
 				4CF89C871A6E2F60001BFDE1 /* Frameworks */,
@@ -330,14 +330,14 @@
 			);
 			dependencies = (
 			);
-			name = "Willow OSX";
+			name = "Willow macOS";
 			productName = "Timber OSX";
 			productReference = 4CF89C8B1A6E2F60001BFDE1 /* Willow.framework */;
 			productType = "com.apple.product-type.framework";
 		};
-		4CF89C941A6E2F60001BFDE1 /* Willow OSX Tests */ = {
+		4CF89C941A6E2F60001BFDE1 /* Willow macOS Tests */ = {
 			isa = PBXNativeTarget;
-			buildConfigurationList = 4CF89CA31A6E2F60001BFDE1 /* Build configuration list for PBXNativeTarget "Willow OSX Tests" */;
+			buildConfigurationList = 4CF89CA31A6E2F60001BFDE1 /* Build configuration list for PBXNativeTarget "Willow macOS Tests" */;
 			buildPhases = (
 				4CF89C911A6E2F60001BFDE1 /* Sources */,
 				4CF89C921A6E2F60001BFDE1 /* Frameworks */,
@@ -348,7 +348,7 @@
 			dependencies = (
 				4CF89C981A6E2F60001BFDE1 /* PBXTargetDependency */,
 			);
-			name = "Willow OSX Tests";
+			name = "Willow macOS Tests";
 			productName = "Timber OSXTests";
 			productReference = 4CF89C951A6E2F60001BFDE1 /* WillowTests.xctest */;
 			productType = "com.apple.product-type.bundle.unit-test";
@@ -441,8 +441,8 @@
 			targets = (
 				4CFE82981A6C484A0002868E /* Willow iOS */,
 				4CFE82A31A6C484A0002868E /* Willow iOS Tests */,
-				4CF89C8A1A6E2F60001BFDE1 /* Willow OSX */,
-				4CF89C941A6E2F60001BFDE1 /* Willow OSX Tests */,
+				4CF89C8A1A6E2F60001BFDE1 /* Willow macOS */,
+				4CF89C941A6E2F60001BFDE1 /* Willow macOS Tests */,
 				4C88351D1C82506600F70419 /* Willow tvOS */,
 				4C8835261C82506600F70419 /* Willow tvOS Tests */,
 				4CA33F2B1B7556D60047C307 /* Willow watchOS */,
@@ -597,7 +597,7 @@
 		};
 		4CF89C981A6E2F60001BFDE1 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
-			target = 4CF89C8A1A6E2F60001BFDE1 /* Willow OSX */;
+			target = 4CF89C8A1A6E2F60001BFDE1 /* Willow macOS */;
 			targetProxy = 4CF89C971A6E2F60001BFDE1 /* PBXContainerItemProxy */;
 		};
 		4CFE82A71A6C484A0002868E /* PBXTargetDependency */ = {
@@ -1025,7 +1025,7 @@
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
-		4CF89CA21A6E2F60001BFDE1 /* Build configuration list for PBXNativeTarget "Willow OSX" */ = {
+		4CF89CA21A6E2F60001BFDE1 /* Build configuration list for PBXNativeTarget "Willow macOS" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
 				4CF89C9E1A6E2F60001BFDE1 /* Debug */,
@@ -1034,7 +1034,7 @@
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
-		4CF89CA31A6E2F60001BFDE1 /* Build configuration list for PBXNativeTarget "Willow OSX Tests" */ = {
+		4CF89CA31A6E2F60001BFDE1 /* Build configuration list for PBXNativeTarget "Willow macOS Tests" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
 				4CF89CA01A6E2F60001BFDE1 /* Debug */,

--- a/Willow.xcodeproj/project.pbxproj
+++ b/Willow.xcodeproj/project.pbxproj
@@ -396,30 +396,30 @@
 			isa = PBXProject;
 			attributes = {
 				LastSwiftUpdateCheck = 0800;
-				LastUpgradeCheck = 0800;
+				LastUpgradeCheck = 0820;
 				ORGANIZATIONNAME = Nike;
 				TargetAttributes = {
 					4C88351D1C82506600F70419 = {
 						CreatedOnToolsVersion = 7.2.1;
-						ProvisioningStyle = Automatic;
+						ProvisioningStyle = Manual;
 					};
 					4C8835261C82506600F70419 = {
 						CreatedOnToolsVersion = 7.2.1;
 					};
 					4CA33F2B1B7556D60047C307 = {
 						CreatedOnToolsVersion = 7.0;
-						ProvisioningStyle = Automatic;
+						ProvisioningStyle = Manual;
 					};
 					4CF89C8A1A6E2F60001BFDE1 = {
 						CreatedOnToolsVersion = 6.2;
-						ProvisioningStyle = Automatic;
+						ProvisioningStyle = Manual;
 					};
 					4CF89C941A6E2F60001BFDE1 = {
 						CreatedOnToolsVersion = 6.2;
 					};
 					4CFE82981A6C484A0002868E = {
 						CreatedOnToolsVersion = 6.1.1;
-						ProvisioningStyle = Automatic;
+						ProvisioningStyle = Manual;
 					};
 					4CFE82A31A6C484A0002868E = {
 						CreatedOnToolsVersion = 6.1.1;
@@ -611,9 +611,10 @@
 		4C88352F1C82506600F70419 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "iPhone Developer";
+				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
 				DEBUG_INFORMATION_FORMAT = dwarf;
 				DEFINES_MODULE = YES;
+				DEVELOPMENT_TEAM = "";
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
@@ -632,10 +633,11 @@
 		4C8835301C82506600F70419 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "iPhone Developer";
+				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
 				COPY_PHASE_STRIP = NO;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				DEFINES_MODULE = YES;
+				DEVELOPMENT_TEAM = "";
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
@@ -685,9 +687,10 @@
 		4CA33F321B7556D60047C307 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "iPhone Developer";
+				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
 				DEBUG_INFORMATION_FORMAT = dwarf;
 				DEFINES_MODULE = YES;
+				DEVELOPMENT_TEAM = "";
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
@@ -706,10 +709,11 @@
 		4CA33F331B7556D60047C307 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "iPhone Developer";
+				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
 				COPY_PHASE_STRIP = NO;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				DEFINES_MODULE = YES;
+				DEVELOPMENT_TEAM = "";
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
@@ -729,9 +733,10 @@
 		4CF89C9E1A6E2F60001BFDE1 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				CODE_SIGN_IDENTITY = "Mac Developer";
+				CODE_SIGN_IDENTITY = "";
 				COMBINE_HIDPI_IMAGES = YES;
 				DEFINES_MODULE = YES;
+				DEVELOPMENT_TEAM = "";
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
@@ -753,11 +758,12 @@
 		4CF89C9F1A6E2F60001BFDE1 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				CODE_SIGN_IDENTITY = "Mac Developer";
+				CODE_SIGN_IDENTITY = "";
 				COMBINE_HIDPI_IMAGES = YES;
 				COPY_PHASE_STRIP = NO;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				DEFINES_MODULE = YES;
+				DEVELOPMENT_TEAM = "";
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
@@ -921,6 +927,7 @@
 				CLANG_ENABLE_MODULES = YES;
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
 				DEFINES_MODULE = YES;
+				DEVELOPMENT_TEAM = "";
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
@@ -942,6 +949,7 @@
 				CLANG_ENABLE_MODULES = YES;
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
 				DEFINES_MODULE = YES;
+				DEVELOPMENT_TEAM = "";
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";

--- a/Willow.xcodeproj/xcshareddata/xcschemes/Willow OSX.xcscheme
+++ b/Willow.xcodeproj/xcshareddata/xcschemes/Willow OSX.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0800"
+   LastUpgradeVersion = "0820"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Willow.xcodeproj/xcshareddata/xcschemes/Willow iOS.xcscheme
+++ b/Willow.xcodeproj/xcshareddata/xcschemes/Willow iOS.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0800"
+   LastUpgradeVersion = "0820"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Willow.xcodeproj/xcshareddata/xcschemes/Willow macOS.xcscheme
+++ b/Willow.xcodeproj/xcshareddata/xcschemes/Willow macOS.xcscheme
@@ -16,7 +16,7 @@
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "4CF89C8A1A6E2F60001BFDE1"
                BuildableName = "Willow.framework"
-               BlueprintName = "Willow OSX"
+               BlueprintName = "Willow macOS"
                ReferencedContainer = "container:Willow.xcodeproj">
             </BuildableReference>
          </BuildActionEntry>
@@ -30,7 +30,7 @@
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "4CF89C941A6E2F60001BFDE1"
                BuildableName = "WillowTests.xctest"
-               BlueprintName = "Willow OSX Tests"
+               BlueprintName = "Willow macOS Tests"
                ReferencedContainer = "container:Willow.xcodeproj">
             </BuildableReference>
          </BuildActionEntry>
@@ -48,7 +48,7 @@
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "4CF89C941A6E2F60001BFDE1"
                BuildableName = "WillowTests.xctest"
-               BlueprintName = "Willow OSX Tests"
+               BlueprintName = "Willow macOS Tests"
                ReferencedContainer = "container:Willow.xcodeproj">
             </BuildableReference>
          </TestableReference>
@@ -58,7 +58,7 @@
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "4CF89C8A1A6E2F60001BFDE1"
             BuildableName = "Willow.framework"
-            BlueprintName = "Willow OSX"
+            BlueprintName = "Willow macOS"
             ReferencedContainer = "container:Willow.xcodeproj">
          </BuildableReference>
       </MacroExpansion>
@@ -80,7 +80,7 @@
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "4CF89C8A1A6E2F60001BFDE1"
             BuildableName = "Willow.framework"
-            BlueprintName = "Willow OSX"
+            BlueprintName = "Willow macOS"
             ReferencedContainer = "container:Willow.xcodeproj">
          </BuildableReference>
       </MacroExpansion>
@@ -98,7 +98,7 @@
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "4CF89C8A1A6E2F60001BFDE1"
             BuildableName = "Willow.framework"
-            BlueprintName = "Willow OSX"
+            BlueprintName = "Willow macOS"
             ReferencedContainer = "container:Willow.xcodeproj">
          </BuildableReference>
       </MacroExpansion>

--- a/Willow.xcodeproj/xcshareddata/xcschemes/Willow tvOS.xcscheme
+++ b/Willow.xcodeproj/xcshareddata/xcschemes/Willow tvOS.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0800"
+   LastUpgradeVersion = "0820"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Willow.xcodeproj/xcshareddata/xcschemes/Willow watchOS.xcscheme
+++ b/Willow.xcodeproj/xcshareddata/xcschemes/Willow watchOS.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0800"
+   LastUpgradeVersion = "0820"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"


### PR DESCRIPTION
This PR contains a bunch of small changes to prep the Willow 3.0.0 release. The main reason we need to bump the MAJOR version is due to cf5d8c8. We missed the lowercasing on the `ExecutionMethod`, so better to just fix rather than have it stick out like a sore thumb for everyone. The rest of the changes are mostly project and Travis-CI related.