### PR TITLE
Correct ExecutionMethod enum casing in example

### DIFF
--- a/Example/Frameworks/Database/Logger.swift
+++ b/Example/Frameworks/Database/Logger.swift
@@ -55,7 +55,7 @@ public var log: Logger! = {
 
     let modifiers: [LogLevel: [LogMessageModifier]] = [.all: [PrefixModifier(), TimestampModifier()]]
     let queue = DispatchQueue(label: "com.nike.database.logger.queue", qos: .utility)
-    let configuration = LoggerConfiguration(modifiers: modifiers, executionMethod: .Asynchronous(queue: queue))
+    let configuration = LoggerConfiguration(modifiers: modifiers, executionMethod: .asynchronous(queue: queue))
 
     return Logger(configuration: configuration)
 }()

--- a/Example/Frameworks/Network/Logger.swift
+++ b/Example/Frameworks/Network/Logger.swift
@@ -36,7 +36,7 @@ public var log: Logger = {
 
     let modifiers: [LogLevel: [LogMessageModifier]] = [.all: [PrefixModifier(), TimestampModifier()]]
     let queue = DispatchQueue(label: "com.nike.network.logger.queue", qos: .utility)
-    let configuration = LoggerConfiguration(modifiers: modifiers, executionMethod: .Asynchronous(queue: queue))
+    let configuration = LoggerConfiguration(modifiers: modifiers, executionMethod: .asynchronous(queue: queue))
 
     return Logger(configuration: configuration)
 }()

--- a/Example/iOS Example/WillowConfiguration.swift
+++ b/Example/iOS Example/WillowConfiguration.swift
@@ -72,9 +72,9 @@ struct WillowConfiguration {
         let executionMethod: LoggerConfiguration.ExecutionMethod
 
         if asynchronous {
-            executionMethod = .Synchronous(lock: NSRecursiveLock())
+            executionMethod = .synchronous(lock: NSRecursiveLock())
         } else {
-            executionMethod = .Asynchronous(
+            executionMethod = .asynchronous(
                 queue: DispatchQueue(label: "com.nike.example.logger", qos: .utility)
             )
         }


### PR DESCRIPTION
Fix the casing of the `ExecutionMethod` enums within the example project