### PR TITLE
 Make modifiers non-optional in writeMessage()

### DIFF
--- a/Source/LogMessageWriter.swift
+++ b/Source/LogMessageWriter.swift
@@ -29,7 +29,7 @@ import os
 /// the conforming object sees fit. For example, it could write to the console, write to a file, remote log to a third
 /// party service, etc.
 public protocol LogMessageWriter {
-    func writeMessage(_ message: String, logLevel: LogLevel, modifiers: [LogMessageModifier]?)
+    func writeMessage(_ message: String, logLevel: LogLevel, modifiers: [LogMessageModifier])
 }
 
 // MARK: -
@@ -69,9 +69,9 @@ open class ConsoleWriter: LogMessageWriter {
     ///   - message:   The original message to write to the console.
     ///   - logLevel:  The log level associated with the message.
     ///   - modifiers: The modifier objects to run over the message before writing to the console.
-    open func writeMessage(_ message: String, logLevel: LogLevel, modifiers: [LogMessageModifier]?) {
+    open func writeMessage(_ message: String, logLevel: LogLevel, modifiers: [LogMessageModifier]) {
         var message = message
-        modifiers?.forEach { message = $0.modifyMessage(message, with: logLevel) }
+        modifiers.forEach { message = $0.modifyMessage(message, with: logLevel) }
 
         switch method {
         case .print:
@@ -113,9 +113,9 @@ open class OSLogWriter: LogMessageWriter {
     ///   - message:   The original message to write to the console.
     ///   - logLevel:  The log level associated with the message.
     ///   - modifiers: The modifier objects to run over the message before writing to the console.
-    open func writeMessage(_ message: String, logLevel: LogLevel, modifiers: [LogMessageModifier]?) {
+    open func writeMessage(_ message: String, logLevel: LogLevel, modifiers: [LogMessageModifier]) {
         var message = message
-        modifiers?.forEach { message = $0.modifyMessage(message, with: logLevel) }
+        modifiers.forEach { message = $0.modifyMessage(message, with: logLevel) }
 
         let logType: OSLogType
 

--- a/Source/Logger.swift
+++ b/Source/Logger.swift
@@ -153,7 +153,7 @@ open class Logger {
     }
 
     private func logMessage(_ message: String, with logLevel: LogLevel) {
-        let modifiers = configuration.modifiers[logLevel]
+        let modifiers = configuration.modifiers[logLevel] ?? []
         configuration.writers[logLevel]?.forEach { $0.writeMessage(message, logLevel: logLevel, modifiers: modifiers) }
     }
 }

--- a/Tests/LogLevelTests.swift
+++ b/Tests/LogLevelTests.swift
@@ -57,7 +57,7 @@ class TestWriter: LogMessageWriter {
     private(set) var actualNumberOfWrites: Int = 0
     private(set) var message: String?
 
-    func writeMessage(_ message: String, logLevel: LogLevel, modifiers: [LogMessageModifier]?) {
+    func writeMessage(_ message: String, logLevel: LogLevel, modifiers: [LogMessageModifier]) {
         self.message = message
         actualNumberOfWrites += 1
     }

--- a/Tests/LoggerTests.swift
+++ b/Tests/LoggerTests.swift
@@ -39,10 +39,10 @@ class SynchronousTestWriter: LogMessageWriter {
     private(set) var message: String?
     private(set) var modifiedMessages = [String]()
 
-    func writeMessage(_ message: String, logLevel: LogLevel, modifiers: [LogMessageModifier]?) {
+    func writeMessage(_ message: String, logLevel: LogLevel, modifiers: [LogMessageModifier]) {
         var mutableMessage = message
 
-        if let modifiers = modifiers {
+        if !modifiers.isEmpty {
             modifiers.forEach { mutableMessage = $0.modifyMessage(mutableMessage, with: logLevel) }
             modifiedMessages.append(mutableMessage)
         }
@@ -64,7 +64,7 @@ class AsynchronousTestWriter: SynchronousTestWriter {
         self.expectedNumberOfWrites = expectedNumberOfWrites
     }
 
-    override func writeMessage(_ message: String, logLevel: LogLevel, modifiers: [LogMessageModifier]?) {
+    override func writeMessage(_ message: String, logLevel: LogLevel, modifiers: [LogMessageModifier]) {
         super.writeMessage(message, logLevel: logLevel, modifiers: modifiers)
 
         if actualNumberOfWrites == expectedNumberOfWrites {


### PR DESCRIPTION
An empty `modifiers` array in `writeMessage()` should have the same behavior as nil array. Removing the optionality of the array simplifies the implementation of the protocol.

This is a **breaking change** to a public protocol. It's understandable to hold off on this change until the next major release. I'm open to feedback / discussion over whether this change is warranted.