### PR TITLE
Bugfix - Ambiguity in Escaping Closure APIs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,12 @@
 .DS_Store
 
 # Xcode
+
+## Build generated
 build/
+DerivedData
+
+## Various settings
 *.pbxuser
 !default.pbxuser
 *.mode1v3
@@ -12,9 +17,19 @@ build/
 *.perspectivev3
 !default.perspectivev3
 xcuserdata
+
+## Other
 *.xccheckout
 *.moved-aside
-DerivedData
+*.xcuserstate
+*.xcscmblueprint
+
+## Obj-C/Swift specific
 *.hmap
 *.ipa
-*.xcuserstate
+
+# Carthage
+Carthage/Build
+
+# Swift Package Manager
+.build/

--- a/.travis.yml
+++ b/.travis.yml
@@ -55,5 +55,5 @@ script:
 
   # Run `pod lib lint` if specified
   - if [ $POD_LINT == "YES" ]; then
-      pod lib lint --private;
+      pod lib lint;
     fi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 `Willow` adheres to [Semantic Versioning](http://semver.org/).
 
+#### 5.x Releases
+
+- `5.0.x` Releases - [5.0.0](#500)
+
 #### 4.x Releases
 
 - `4.0.x` Releases - [4.0.0](#400)
@@ -20,6 +24,31 @@ All notable changes to this project will be documented in this file.
 - `1.2.x` Releases - [1.2.0](#120)
 - `1.1.x` Releases - [1.1.0](#110)
 - `1.0.x` Releases - [1.0.0](#100)
+
+---
+
+## [5.0.0](https://github.com/Nike-Inc/Willow/releases/tag/5.0.0)
+
+Released on 2017-09-20. All issues associated with this milestone can be found using this
+[filter](https://github.com/Nike-Inc/Willow/milestone/6?closed=1).
+
+#### Added
+
+- Migration Guide for Willow 5 and added it to the README.
+  - Added by [Christian Noon](https://github.com/cnoon) in Pull Request
+  [#32](https://github.com/Nike-Inc/Willow/pull/32).
+
+#### Updated
+
+- Log message string APIs to include `Message` suffix to remove ambiguity with `LogMessage` APIs.
+  - Updated by [Christian Noon](https://github.com/cnoon) in Pull Request
+  [#32](https://github.com/Nike-Inc/Willow/pull/32).
+- The README to match the updated APIs.
+  - Updated by [Christian Noon](https://github.com/cnoon) in Pull Request
+  [#32](https://github.com/Nike-Inc/Willow/pull/32).
+- The `Package` file to be compatible with SPM v4.
+  - Updated by [Christian Noon](https://github.com/cnoon) in Pull Request
+  [#32](https://github.com/Nike-Inc/Willow/pull/32).
 
 ---
 

--- a/Documentation/Willow 5.0 Migration Guide.md
+++ b/Documentation/Willow 5.0 Migration Guide.md
@@ -1,0 +1,69 @@
+# Willow 5.0 Migration Guide
+
+Willow 5.0 is the latest major release of Willow, a powerful, yet lightweight logging library for iOS, macOS, tvOS and watchOS written in Swift.
+As a major release, following Semantic Versioning conventions, 5.0 introduces several API-breaking changes that one should be aware of.
+
+This guide is provided in order to ease the transition of existing applications using Willow 4.x to the latest APIs.
+
+## Requirements
+
+Willow 5.0 officially supports iOS 9.0+, macOS 10.11+, tvOS 9.0+, watchOS 2.0+, Xcode 9.0+ and Swift 4.0+.
+If you'd like to use Willow in a project targeting Xcode 8.3 and Swift 3.1, use the latest tagged 3.x release.
+
+---
+
+## Breaking API Changes
+
+Willow 5.0 contains very minor breaking changes on the log message string APIs.
+Most of your Willow code will be able to remain the same.
+
+### Logger APIs
+
+Unfortunately, in the Willow 4.0.0 release, we missed the fact that multi-line escaping closures are ambiguous with different return types.
+For example, the following call was ambiguous in Willow 4:
+
+```swift
+log.event {
+    let value = 10
+    return "Total value is: \(value)"
+}
+```
+
+The only way to correct the ambiguity error is to declare the closure signature for the compiler:
+
+```swift
+log.event { () -> String in
+    let value = 10
+    return "Total value is: \(value)"
+}
+```
+
+This was certainly not intended and was an unfortunate oversight on our part.
+Single line closures did not exhibit the issue, but multi-line escaping closures certainly do.
+
+To resolve this issue in Willow 5, we've modified the log message string APIs to include the `Message` suffix.
+
+```swift
+log.eventMessage {
+    let value = 10
+    return "Total value is: \(value)"
+}
+```
+
+The `LogMessage` APIs do not include the `Message` suffix which satisfies the compiler.
+Sadly we were unable to make this change in a backwards compatible way.
+However, it is a very simple change to make to migrate from Willow 4 to Willow 5.
+
+### Optional APIs
+
+The `Optional<Logger>` extension APIs have also been updated to use the `Message` suffix for log message string APIs.
+
+```swift
+var log: Logger?
+
+log.eventMessage {
+    let value = 10
+    return "Total value is: \(value)"
+}
+```
+

--- a/Example/Frameworks/Database.xcodeproj/xcshareddata/xcschemes/Database.xcscheme
+++ b/Example/Frameworks/Database.xcodeproj/xcshareddata/xcschemes/Database.xcscheme
@@ -1,0 +1,82 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "0900"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "4C2DC4181CDEB4F4009CA3C5"
+               BuildableName = "Database.framework"
+               BlueprintName = "Database"
+               ReferencedContainer = "container:Database.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      language = ""
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+      </Testables>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      language = ""
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "4C2DC4181CDEB4F4009CA3C5"
+            BuildableName = "Database.framework"
+            BlueprintName = "Database"
+            ReferencedContainer = "container:Database.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "4C2DC4181CDEB4F4009CA3C5"
+            BuildableName = "Database.framework"
+            BlueprintName = "Database"
+            ReferencedContainer = "container:Database.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/Example/Frameworks/Database/Connection.swift
+++ b/Example/Frameworks/Database/Connection.swift
@@ -42,7 +42,7 @@ public class Connection {
     }
 
     public static func makeInfoCall() {
-        log.info("Making call that logs info message")
+        log.infoMessage("Making call that logs info message")
     }
 
     public static func makeEventCall() {
@@ -50,7 +50,7 @@ public class Connection {
     }
 
     public static func makeWarnCall() {
-        log.warn("Making call that logs warn message")
+        log.warnMessage("Making call that logs warn message")
     }
 
     public static func makeErrorCall() {

--- a/Example/Frameworks/Database/Connection.swift
+++ b/Example/Frameworks/Database/Connection.swift
@@ -1,7 +1,7 @@
 //
 //  Connection.swift
 //
-//  Copyright (c) 2015-2017 Nike, Inc. (https://www.nike.com)
+//  Copyright (c) 2015-present Nike, Inc. (https://www.nike.com)
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/Example/Frameworks/Database/Database.h
+++ b/Example/Frameworks/Database/Database.h
@@ -1,7 +1,7 @@
 //
 //  Database.h
 //
-//  Copyright (c) 2015-2017 Nike, Inc. (https://www.nike.com)
+//  Copyright (c) 2015-present Nike, Inc. (https://www.nike.com)
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/Example/Frameworks/Database/Logger.swift
+++ b/Example/Frameworks/Database/Logger.swift
@@ -1,7 +1,7 @@
 //
 //  Logger.swift
 //
-//  Copyright (c) 2015-2017 Nike, Inc. (https://www.nike.com)
+//  Copyright (c) 2015-present Nike, Inc. (https://www.nike.com)
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/Example/Frameworks/WebServices.xcodeproj/xcshareddata/xcschemes/WebServices.xcscheme
+++ b/Example/Frameworks/WebServices.xcodeproj/xcshareddata/xcschemes/WebServices.xcscheme
@@ -1,0 +1,82 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "0900"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "4C2DC3E31CDEB279009CA3C5"
+               BuildableName = "WebServices.framework"
+               BlueprintName = "WebServices"
+               ReferencedContainer = "container:WebServices.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      language = ""
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+      </Testables>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      language = ""
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "4C2DC3E31CDEB279009CA3C5"
+            BuildableName = "WebServices.framework"
+            BlueprintName = "WebServices"
+            ReferencedContainer = "container:WebServices.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "4C2DC3E31CDEB279009CA3C5"
+            BuildableName = "WebServices.framework"
+            BlueprintName = "WebServices"
+            ReferencedContainer = "container:WebServices.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/Example/Frameworks/WebServices/Logger.swift
+++ b/Example/Frameworks/WebServices/Logger.swift
@@ -58,16 +58,18 @@ enum Message: Willow.LogMessage {
 
         case let .requestCompleted(request, response):
             keyPathAttributes[.url] = request.url
-            keyPathAttributes[.respopnseCode] = response.statusCode
+            keyPathAttributes[.responseCode] = response.statusCode
             success = true
 
         case let .requestFailed(request, response, error):
             keyPathAttributes[.url] = request.url
-            keyPathAttributes[.respopnseCode] = response.statusCode
+            keyPathAttributes[.responseCode] = response.statusCode
+
             if let error = error {
-                keyPathAttributes[.errorDescription] = message(forError: error)
-                keyPathAttributes[.errorCode] = code(forError: error)
+                keyPathAttributes[.errorDescription] = message(for: error)
+                keyPathAttributes[.errorCode] = code(for: error)
             }
+
             success = false
         }
 
@@ -97,18 +99,18 @@ enum Message: Willow.LogMessage {
     private enum KeyPath: String {
         case url                = "url"
         case result             = "result"
-        case respopnseCode      = "response_code"
+        case responseCode       = "response_code"
         case errorDescription   = "error_description"
         case errorCode          = "error_code"
         case frameworkName      = "framework_name"
         case frameworkVersion   = "framework_version"
     }
 
-    private func code(forError error: Error) -> Int {
+    private func code(for error: Error) -> Int {
         return (error as NSError).code
     }
 
-    private func message(forError error: Error) -> String {
+    private func message(for error: Error) -> String {
         return (error as NSError).localizedDescription
     }
 }

--- a/Example/Frameworks/WebServices/Logger.swift
+++ b/Example/Frameworks/WebServices/Logger.swift
@@ -1,7 +1,7 @@
 //
 //  Logger.swift
 //
-//  Copyright (c) 2015-2017 Nike, Inc. (https://www.nike.com)
+//  Copyright (c) 2015-present Nike, Inc. (https://www.nike.com)
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/Example/Frameworks/WebServices/Request.swift
+++ b/Example/Frameworks/WebServices/Request.swift
@@ -1,7 +1,7 @@
 //
 //  Request.swift
 //
-//  Copyright (c) 2015-2017 Nike, Inc. (https://www.nike.com)
+//  Copyright (c) 2015-present Nike, Inc. (https://www.nike.com)
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/Example/Frameworks/WebServices/Request.swift
+++ b/Example/Frameworks/WebServices/Request.swift
@@ -26,11 +26,11 @@ import Foundation
 
 public class Request {
     public static func makeDebugRequest() {
-        log.debug("Making request that logs debug message")
+        log.debugMessage("Making request that logs debug message")
     }
 
     public static func makeInfoRequest() {
-        log.info("Making request that logs info message")
+        log.infoMessage("Making request that logs info message")
     }
 
     public static func makeEventRequest() {
@@ -44,7 +44,7 @@ public class Request {
     }
 
     public static func makeWarnRequest() {
-        log.warn("Making request that logs warn message")
+        log.warnMessage("Making request that logs warn message")
     }
 
     public static func makeErrorRequest() {

--- a/Example/Frameworks/WebServices/WebServices.h
+++ b/Example/Frameworks/WebServices/WebServices.h
@@ -1,7 +1,7 @@
 //
 //  WebServices.h
 //
-//  Copyright (c) 2015-2017 Nike, Inc. (https://www.nike.com)
+//  Copyright (c) 2015-present Nike, Inc. (https://www.nike.com)
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/Example/iOS Example/AppDelegate.swift
+++ b/Example/iOS Example/AppDelegate.swift
@@ -1,7 +1,7 @@
 //
 //  AppDelegate.swift
 //
-//  Copyright (c) 2015-2017 Nike, Inc. (https://www.nike.com)
+//  Copyright (c) 2015-present Nike, Inc. (https://www.nike.com)
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/Example/iOS Example/Base.lproj/LaunchScreen.xib
+++ b/Example/iOS Example/Base.lproj/LaunchScreen.xib
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="13189.4" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" launchScreen="YES" useTraitCollections="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="13196" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" launchScreen="YES" useTraitCollections="YES" colorMatched="YES">
     <device id="retina4_7" orientation="portrait">
         <adaptation id="fullscreen"/>
     </device>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="13165.3"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="13173"/>
         <capability name="Constraints with non-1.0 multipliers" minToolsVersion="5.1"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -16,7 +16,7 @@
             <rect key="frame" x="0.0" y="0.0" width="480" height="480"/>
             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
             <subviews>
-                <label opaque="NO" clipsSubviews="YES" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="  Copyright (c) 2017 Nike. All rights reserved." textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumFontSize="9" translatesAutoresizingMaskIntoConstraints="NO" id="8ie-xW-0ye">
+                <label opaque="NO" clipsSubviews="YES" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="  Copyright (c) Nike. All rights reserved." textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumFontSize="9" translatesAutoresizingMaskIntoConstraints="NO" id="8ie-xW-0ye">
                     <rect key="frame" x="20" y="439" width="441" height="21"/>
                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                     <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>

--- a/Example/iOS Example/ViewController.swift
+++ b/Example/iOS Example/ViewController.swift
@@ -1,7 +1,7 @@
 //
 //  ViewController.swift
 //
-//  Copyright (c) 2015-2017 Nike, Inc. (https://www.nike.com)
+//  Copyright (c) 2015-present Nike, Inc. (https://www.nike.com)
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/Example/iOS Example/ViewController.swift
+++ b/Example/iOS Example/ViewController.swift
@@ -78,23 +78,23 @@ class ViewController: UIViewController {
                 items: [
                     Item(
                         title: "Log Debug Message",
-                        action: { log.debug { "Logging Debug Message" } }
+                        action: { log.debugMessage { "Logging Debug Message" } }
                     ),
                     Item(
                         title: "Log Info Message",
-                        action: { log.info { "Logging Info Message" } }
+                        action: { log.infoMessage { "Logging Info Message" } }
                     ),
                     Item(
                         title: "Log Event Message",
-                        action: { log.event { "Logging Event Message" } }
+                        action: { log.eventMessage { "Logging Event Message" } }
                     ),
                     Item(
                         title: "Log Warn Message",
-                        action: { log.warn { "Logging Warn Message" } }
+                        action: { log.warnMessage { "Logging Warn Message" } }
                     ),
                     Item(
                         title: "Log Error Message",
-                        action: { log.error { "Logging Error Message" } }
+                        action: { log.errorMessage { "Logging Error Message" } }
                     )
                 ]
             ),
@@ -162,25 +162,11 @@ class ViewController: UIViewController {
                             let queue = DispatchQueue.global()
 
                             for _ in range {
-                                queue.async {
-                                    log.debug { "Logging debug message" }
-                                }
-
-                                queue.async {
-                                    log.info { "Logging info message" }
-                                }
-
-                                queue.async {
-                                    log.event { "Logging event message" }
-                                }
-
-                                queue.async {
-                                    log.warn { "Logging warn message" }
-                                }
-
-                                queue.async {
-                                    log.error { "Logging error message" }
-                                }
+                                queue.async { log.debugMessage("Logging debug message") }
+                                queue.async { log.infoMessage("Logging info message") }
+                                queue.async { log.eventMessage("Logging event message") }
+                                queue.async { log.warnMessage("Logging warn message") }
+                                queue.async { log.errorMessage("Logging error message") }
                             }
                         }
                     ),
@@ -192,11 +178,11 @@ class ViewController: UIViewController {
 
                             for _ in range {
                                 queue.async {
-                                    log.debug { "Logging debug message" }
-                                    log.info { "Logging info message" }
-                                    log.event { "Logging event message" }
-                                    log.warn { "Logging warn message" }
-                                    log.error { "Logging error message" }
+                                    log.debugMessage("Logging debug message")
+                                    log.infoMessage("Logging info message")
+                                    log.eventMessage("Logging event message")
+                                    log.warnMessage("Logging warn message")
+                                    log.errorMessage("Logging error message")
                                 }
 
                                 queue.async {

--- a/Example/iOS Example/WillowConfiguration.swift
+++ b/Example/iOS Example/WillowConfiguration.swift
@@ -1,7 +1,7 @@
 //
 //  WillowConfiguration.swift
 //
-//  Copyright (c) 2015-2017 Nike, Inc. (https://www.nike.com)
+//  Copyright (c) 2015-present Nike, Inc. (https://www.nike.com)
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2015-2017 Nike, Inc. (https://www.nike.com)
+Copyright (c) 2015-present Nike, Inc. (https://www.nike.com)
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/Package.swift
+++ b/Package.swift
@@ -1,7 +1,7 @@
 //
 //  Package.swift
 //
-//  Copyright (c) 2015-2017 Nike, Inc. (https://www.nike.com)
+//  Copyright (c) 2015-present Nike, Inc. (https://www.nike.com)
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/Package.swift
+++ b/Package.swift
@@ -1,3 +1,5 @@
+// swift-tools-version:4.0
+// The swift-tools-version declares the minimum version of Swift required to build this package.
 //
 //  Package.swift
 //
@@ -24,4 +26,13 @@
 
 import PackageDescription
 
-let package = Package(name: "Willow", swiftLanguageVersions: [4], exclude: ["Tests"])
+let package = Package(
+    name: "Willow",
+    products: [
+        .library(name: "Willow", targets: ["Willow"])
+    ],
+    targets: [
+        .target(name: "Willow", path: "", sources: ["Source"])
+    ],
+    swiftLanguageVersions: [4]
+)

--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ Willow is a powerful, yet lightweight logging library written in Swift.
 - [Willow 2.0 Migration Guide](https://github.com/Nike-Inc/Willow/blob/master/Documentation/Willow%202.0%20Migration%20Guide.md)
 - [Willow 3.0 Migration Guide](https://github.com/Nike-Inc/Willow/blob/master/Documentation/Willow%203.0%20Migration%20Guide.md)
 - [Willow 4.0 Migration Guide](https://github.com/Nike-Inc/Willow/blob/master/Documentation/Willow%204.0%20Migration%20Guide.md)
+- [Willow 5.0 Migration Guide](https://github.com/Nike-Inc/Willow/blob/master/Documentation/Willow%205.0%20Migration%20Guide.md)
 
 ## Communication
 

--- a/README.md
+++ b/README.md
@@ -75,16 +75,16 @@ You can install it with the following command:
 [sudo] gem install cocoapods
 ```
 
-> CocoaPods 1.1+ is required.
+> CocoaPods 1.3+ is required.
 
 To integrate Willow into your project, specify it in your [Podfile](http://guides.cocoapods.org/using/the-podfile.html):
 
 ```ruby
 source 'https://github.com/CocoaPods/Specs.git'
-platform :ios, '10.0'
+platform :ios, '11.0'
 use_frameworks!
 
-pod 'Willow', '~> 4.0'
+pod 'Willow', '~> 5.0'
 ```
 
 Then, run the following command:
@@ -107,7 +107,7 @@ $ brew install carthage
 To integrate Willow into your Xcode project using Carthage, specify it in your [Cartfile](https://github.com/Carthage/Carthage/blob/master/Documentation/Artifacts.md#cartfile):
 
 ```
-github "Nike-Inc/Willow" ~> 4.0
+github "Nike-Inc/Willow" ~> 5.0
 ```
 
 Run `carthage update` to build the framework and drag the built `Willow.framework` into your Xcode project.
@@ -121,7 +121,7 @@ Once you have your Swift package set up, adding Willow as a dependency is as eas
 
 ```swift
 dependencies: [
-    .package(url: "https://github.com/Nike-Inc/Willow.git", majorVersion: 4)
+    .package(url: "https://github.com/Nike-Inc/Willow.git", majorVersion: 5)
 ]
 ```
 
@@ -163,13 +163,62 @@ If two `print` calls are happening simultaneously from two different queues (thr
 
 ### Logging Messages and String Messages
 
-Willow can log two different types: Messages and Strings. 
+Willow can log two different types of objects: Messages and Strings.
 
- - Messages are structured data with a name and a dictionary of attributes.
- Willow declares the `LogMessage` protocol which frameworks and applications can use as the basis for concrete implementations.
- Messages are a good choice if you want to provide context information along with the log text (e.g. routing log information to an external system like New Relic).
+#### Log Messages
 
- - Strings are just `Strings` with no additional data.
+Messages are structured data with a name and a dictionary of attributes.
+Willow declares the `LogMessage` protocol which frameworks and applications can use as the basis for concrete implementations.
+Messages are a good choice if you want to provide context information along with the log text (e.g. routing log information to an external system like New Relic).
+
+```swift
+enum Message: LogMessage {
+    case requestStarted(url: URL)
+    case requestCompleted(url: URL, response: HTTPURLResponse)
+
+    var name: String {
+        switch self {
+        case .requestStarted:   return "Request started"
+        case .requestCompleted: return "Request completed"
+        }
+    }
+
+    var attributes: [String: Any] {
+        switch self {
+        case let .requestStarted(url):
+            return ["url": url]
+
+        case let .requestCompleted(url, response):
+            return ["url": url, "response_code": response.statusCode]
+        }
+    }
+}
+
+let url = URL(string: "https://httpbin.org/get")!
+
+log.debug(Message.requestStarted(url: url))
+log.info(Message.requestStarted(url: url))
+log.event(Message.requestStarted(url: url))
+log.warn(Message.requestStarted(url: url))
+log.error(Message.requestStarted(url: url))
+```
+
+#### Log Message Strings
+
+Log message strings are just `String` instances with no additional data.
+
+```swift
+let url = URL(string: "https://httpbin.org/get")!
+
+log.debugMessage("Request Started: \(url)")
+log.infoMessage("Request Started: \(url)")
+log.eventMessage("Request Started: \(url)")
+log.warnMessage("Request Started: \(url)")
+log.errorMessage("Request Started: \(url)")
+```
+
+> The log message string APIs have the `Message` suffix on the end to avoid ambiguity with the log message APIs.
+> The multi-line escaping closure APIs collide without the suffix.
 
 ### Logging Messages with Closures
 
@@ -182,20 +231,20 @@ Developers should be able to focus on the task at hand and not remembering how t
 let log = Logger()
 
 // Option 1
-log.debug("Debug Message")    // Debug Message
-log.info("Info Message")      // Info Message
-log.event("Event Message")    // Event Message
-log.warn("Warn Message")      // Warn Message
-log.error("Error Message")    // Error Message
+log.debugMessage("Debug Message")    // Debug Message
+log.infoMessage("Info Message")      // Info Message
+log.eventMessage("Event Message")    // Event Message
+log.warnMessage("Warn Message")      // Warn Message
+log.errorMessage("Error Message")    // Error Message
 
 // or
 
 // Option 2
-log.debug { "Debug Message" } // Debug Message
-log.info { "Info Message" }   // Info Message
-log.event { "Event Message" } // Event Message
-log.warn { "Warn Message" }   // Warn Message
-log.error { "Error Message" } // Error Message
+log.debugMessage { "Debug Message" } // Debug Message
+log.infoMessage { "Info Message" }   // Info Message
+log.eventMessage { "Event Message" } // Event Message
+log.warnMessage { "Warn Message" }   // Warn Message
+log.errorMessage { "Error Message" } // Error Message
 ```
 
 Both of these approaches are equivalent.
@@ -216,14 +265,14 @@ We want to make sure logic is encapsulated and very performant.
 `Willow` log level closures allow you to cleanly wrap all the logic to build up the message.
 
 ```swift
-log.debug {
+log.debugMessage {
     // First let's run a giant for loop to collect some info
     // Now let's scan through the results to get some aggregate values
     // Now I need to format the data
     return "Computed Data Value: \(dataValue)"
 }
 
-log.info {
+log.infoMessage {
     let countriesString = ",".join(countriesArray)
     return "Countries: \(countriesString)"
 }
@@ -362,7 +411,7 @@ Let's walk through using the `TimestampModifier` (prefixes the message with a ti
 
 ```swift
 class EmojiModifier: LogModifier {
-    func modify(_ message: String, with logLevel: Logger.LogLevel) -> String {
+    func modifyMessage(_ message: String, with logLevel: LogLevel) -> String {
         return "🚀🚀🚀 \(message)"
     }
 }
@@ -386,7 +435,7 @@ In order to use it, all you need to do is to create the `LogModifier` instance a
 let writers = [OSLogWriter(subsystem: "com.nike.willow.example", category: "testing")]
 let log = Logger(logLevels: [.all], writers: writers)
 
-log.debug("Hello world...coming to your from the os_log APIs!")
+log.debugMessage("Hello world...coming to your from the os_log APIs!")
 ```
 
 #### Multiple Writers
@@ -445,11 +494,11 @@ Now that we have a custom log level called `verbose`, we need to extend the `Log
 
 ```swift
 extension Logger {
-    public func verbose(_ message: @autoclosure @escaping () -> String) {
+    public func verboseMessage(_ message: @autoclosure @escaping () -> String) {
     	logMessage(message, withLogLevel: .verbose)
     }
 
-    public func verbose(_ message: @escaping () -> String) {
+    public func verboseMessage(_ message: @escaping () -> String) {
     	logMessage(message, withLogLevel: .verbose)
     }
 }
@@ -459,7 +508,7 @@ Finally, using the new log level is a simple as...
 
 ```swift
 let log = Logger(logLevels: [.all], writers: [ConsoleWriter()])
-log.verbose("My first verbose log message!")
+log.verboseMessage("My first verbose log message!")
 ```
 
 > The `all` log level contains a bitmask where all bits are set to 1.
@@ -474,7 +523,7 @@ Let's walk through a quick example of a `Math` framework sharing a `Logger` with
 
 ```swift
 //=========== Inside Math.swift ===========
-public var log = Logger(logLevels [.warn, .error], writers: [ConsoleWriter()]) // We're going to replace this
+public var log: Logger?
 
 //=========== Calculator.swift ===========
 import Math
@@ -482,7 +531,7 @@ import Math
 let writers: [LogMessageWriter] = [FileWriter(), ConsoleWriter()]
 var log = Logger(logLevels: [.all], writers: writers)
 
-// Replace the Math.log with the Calculator.log to share the same Logger instance
+// Set the Math.log instance to the Calculator.log to share the same Logger instance
 Math.log = log
 ```
 
@@ -494,11 +543,11 @@ The previous example showed how to share `Logger` instances between multiple fra
 Something more likely though is that you would want to have each third party library or internal framework to have their own `Logger` with their own configuration.
 The one thing that you really want to share is the `NSRecursiveLock` or `DispatchQueue` that they run on.
 This will ensure all your logging is thread-safe.
-Here's the previous example demonstrating how to create multiple `Logger` instances with different configurations and share the queue.
+Here's the previous example demonstrating how to create multiple `Logger` instances and still share the queue.
 
 ```swift
 //=========== Inside Math.swift ===========
-public var log = Logger(logLevels: [.warn, .error], writers: [ConsoleWriter()]) // We're going to replace this
+public var log: Logger?
 
 //=========== Calculator.swift ===========
 import Math
@@ -508,10 +557,19 @@ let sharedQueue = DispatchQueue(label: "com.math.logger", qos: .utility)
 
 // Create the Calculator.log with multiple writers and a .Debug log level
 let writers: [LogMessageWriter] = [FileWriter(), ConsoleWriter()]
-var log = Logger(logLevels: [.all], writers: writers, executionMethod: .asynchronous(queue: sharedQueue))
+
+var log = Logger(
+    logLevels: [.all],
+    writers: writers,
+    executionMethod: .asynchronous(queue: sharedQueue)
+)
 
 // Replace the Math.log with a new instance with all the same configuration values except a shared queue
-Math.log = Logger(logLevels: math.log.logLevel, writers: math.log.writers, executionMethod: .asynchronous(queue: sharedQueue))
+Math.log = Logger(
+    logLevels: log.logLevels,
+    writers: [ConsoleWriter()],
+    executionMethod: .asynchronous(queue: sharedQueue)
+)
 ```
 
 `Willow` is a very lightweight library, but its flexibility allows it to become very powerful if you so wish.

--- a/Source/Info-tvOS.plist
+++ b/Source/Info-tvOS.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>4.0.0</string>
+	<string>5.0.0</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>

--- a/Source/Info.plist
+++ b/Source/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>4.0.0</string>
+	<string>5.0.0</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>

--- a/Source/LogLevel.swift
+++ b/Source/LogLevel.swift
@@ -1,7 +1,7 @@
 //
 //  LogLevel.swift
 //
-//  Copyright (c) 2015-2017 Nike, Inc. (https://www.nike.com)
+//  Copyright (c) 2015-present Nike, Inc. (https://www.nike.com)
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/Source/LogMessage.swift
+++ b/Source/LogMessage.swift
@@ -1,7 +1,7 @@
 //
 //  LogMessage.swift
 //
-//  Copyright (c) 2015-2017 Nike, Inc. (https://www.nike.com)
+//  Copyright (c) 2015-present Nike, Inc. (https://www.nike.com)
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/Source/LogModifier.swift
+++ b/Source/LogModifier.swift
@@ -1,7 +1,7 @@
 //
 //  LogModifier.swift
 //
-//  Copyright (c) 2015-2017 Nike, Inc. (https://www.nike.com)
+//  Copyright (c) 2015-present Nike, Inc. (https://www.nike.com)
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/Source/LogWriter.swift
+++ b/Source/LogWriter.swift
@@ -1,7 +1,7 @@
 //
 //  LogWriter.swift
 //
-//  Copyright (c) 2015-2017 Nike, Inc. (https://www.nike.com)
+//  Copyright (c) 2015-present Nike, Inc. (https://www.nike.com)
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/Source/Logger.swift
+++ b/Source/Logger.swift
@@ -1,7 +1,7 @@
 //
 //  Logger.swift
 //
-//  Copyright (c) 2015-2017 Nike, Inc. (https://www.nike.com)
+//  Copyright (c) 2015-present Nike, Inc. (https://www.nike.com)
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/Source/Logger.swift
+++ b/Source/Logger.swift
@@ -175,70 +175,70 @@ open class Logger {
     /// Writes out the given message using the logger if the debug log level is set.
     ///
     /// - Parameter message: An autoclosure returning the message to log.
-    open func debug(_ message: @autoclosure @escaping () -> String) {
+    open func debugMessage(_ message: @autoclosure @escaping () -> String) {
         logMessage(message, with: LogLevel.debug)
     }
 
     /// Writes out the given message using the logger if the debug log level is set.
     ///
     /// - Parameter message: A closure returning the message to log.
-    open func debug(_ message: @escaping () -> String) {
+    open func debugMessage(_ message: @escaping () -> String) {
         logMessage(message, with: LogLevel.debug)
     }
 
     /// Writes out the given message using the logger if the info log level is set.
     ///
     /// - Parameter message: An autoclosure returning the message to log.
-    open func info(_ message: @autoclosure @escaping () -> String) {
+    open func infoMessage(_ message: @autoclosure @escaping () -> String) {
         logMessage(message, with: LogLevel.info)
     }
 
     /// Writes out the given message using the logger if the info log level is set.
     ///
     /// - Parameter message: A closure returning the message to log.
-    open func info(_ message: @escaping () -> String) {
+    open func infoMessage(_ message: @escaping () -> String) {
         logMessage(message, with: LogLevel.info)
     }
 
     /// Writes out the given message using the logger if the event log level is set.
     ///
     /// - Parameter message: An autoclosure returning the message to log.
-    open func event(_ message: @autoclosure @escaping () -> String) {
+    open func eventMessage(_ message: @autoclosure @escaping () -> String) {
         logMessage(message, with: LogLevel.event)
     }
 
     /// Writes out the given message using the logger if the event log level is set.
     ///
     /// - Parameter message: A closure returning the message to log.
-    open func event(_ message: @escaping () -> String) {
+    open func eventMessage(_ message: @escaping () -> String) {
         logMessage(message, with: LogLevel.event)
     }
 
     /// Writes out the given message using the logger if the warn log level is set.
     ///
     /// - Parameter message: An autoclosure returning the message to log.
-    open func warn(_ message: @autoclosure @escaping () -> String) {
+    open func warnMessage(_ message: @autoclosure @escaping () -> String) {
         logMessage(message, with: LogLevel.warn)
     }
 
     /// Writes out the given message using the logger if the warn log level is set.
     ///
     /// - Parameter message: A closure returning the message to log.
-    open func warn(_ message: @escaping () -> String) {
+    open func warnMessage(_ message: @escaping () -> String) {
         logMessage(message, with: LogLevel.warn)
     }
 
     /// Writes out the given message using the logger if the error log level is set.
     ///
     /// - Parameter message: An autoclosure returning the message to log.
-    open func error(_ message: @autoclosure @escaping () -> String) {
+    open func errorMessage(_ message: @autoclosure @escaping () -> String) {
         logMessage(message, with: LogLevel.error)
     }
 
     /// Writes out the given message using the logger if the error log level is set.
     ///
     /// - Parameter message: A closure returning the message to log.
-    open func error(_ message: @escaping () -> String) {
+    open func errorMessage(_ message: @escaping () -> String) {
         logMessage(message, with: LogLevel.error)
     }
 
@@ -282,86 +282,6 @@ open class Logger {
 /// This allows for the use of a `Logger?` variable without the calling code needing to
 /// guard or optionally unwrap before using the log.
 extension Optional where Wrapped == Logger {
-    /// Writes out the given message using the optional logger if the debug log level is set.
-    ///
-    /// - Parameter message: An autoclosure returning the message to log.
-    public func debug(_ message: @autoclosure @escaping () -> String) {
-        guard case let .some(log) = self else { return }
-        log.debug(message)
-    }
-
-    /// Writes out the given message using the optional logger if the debug log level is set.
-    ///
-    /// - Parameter message: A closure returning the message to log.
-    public func debug(_ message: @escaping () -> String) {
-        guard case let .some(log) = self else { return }
-        log.debug(message)
-    }
-
-    /// Writes out the given message using the optional logger if the info log level is set.
-    ///
-    /// - Parameter message: An autoclosure returning the message to log.
-    public func info(_ message: @autoclosure @escaping () -> String) {
-        guard case let .some(log) = self else { return }
-        log.info(message)
-    }
-
-    /// Writes out the given message using the optional logger if the info log level is set.
-    ///
-    /// - Parameter message: A closure returning the message to log.
-    public func info(_ message: @escaping () -> String) {
-        guard case let .some(log) = self else { return }
-        log.info(message)
-    }
-
-    /// Writes out the given message using the optional logger if the event log level is set.
-    ///
-    /// - Parameter message: An autoclosure returning the message to log.
-    public func event(_ message: @autoclosure @escaping () -> String) {
-        guard case let .some(log) = self else { return }
-        log.event(message)
-    }
-
-    /// Writes out the given message using the optional logger if the event log level is set.
-    ///
-    /// - Parameter message: A closure returning the message to log.
-    public func event(_ message: @escaping () -> String) {
-        guard case let .some(log) = self else { return }
-        log.event(message)
-    }
-
-    /// Writes out the given message using the optional logger if the warn log level is set.
-    ///
-    /// - Parameter message: An autoclosure returning the message to log.
-    public func warn(_ message: @autoclosure @escaping () -> String) {
-        guard case let .some(log) = self else { return }
-        log.warn(message)
-    }
-
-    /// Writes out the given message using the optional logger if the warn log level is set.
-    ///
-    /// - Parameter message: A closure returning the message to log.
-    public func warn(_ message: @escaping () -> String) {
-        guard case let .some(log) = self else { return }
-        log.warn(message)
-    }
-
-    /// Writes out the given message using the optional logger if the error log level is set.
-    ///
-    /// - Parameter message: An autoclosure returning the message to log.
-    public func error(_ message: @autoclosure @escaping () -> String) {
-        guard case let .some(log) = self else { return }
-        log.error(message)
-    }
-
-    /// Writes out the given message using the optional logger if the error log level is set.
-    ///
-    /// - Parameter message: A closure returning the message to log.
-    public func error(_ message: @escaping () -> String) {
-        guard case let .some(log) = self else { return }
-        log.error(message)
-    }
-
     /// Writes out the given message using the optional logger if the debug log level is set.
     ///
     /// - Parameter message: An autoclosure returning the message to log.
@@ -437,8 +357,88 @@ extension Optional where Wrapped == Logger {
     /// Writes out the given message using the optional logger if the error log level is set.
     ///
     /// - Parameter message: A closure returning the message to log.
-public func error(_ message: @escaping () -> LogMessage) {
+    public func error(_ message: @escaping () -> LogMessage) {
         guard case let .some(log) = self else { return }
         log.error(message)
+    }
+
+    /// Writes out the given message using the optional logger if the debug log level is set.
+    ///
+    /// - Parameter message: An autoclosure returning the message to log.
+    public func debugMessage(_ message: @autoclosure @escaping () -> String) {
+        guard case let .some(log) = self else { return }
+        log.debugMessage(message)
+    }
+
+    /// Writes out the given message using the optional logger if the debug log level is set.
+    ///
+    /// - Parameter message: A closure returning the message to log.
+    public func debugMessage(_ message: @escaping () -> String) {
+        guard case let .some(log) = self else { return }
+        log.debugMessage(message)
+    }
+
+    /// Writes out the given message using the optional logger if the info log level is set.
+    ///
+    /// - Parameter message: An autoclosure returning the message to log.
+    public func infoMessage(_ message: @autoclosure @escaping () -> String) {
+        guard case let .some(log) = self else { return }
+        log.infoMessage(message)
+    }
+
+    /// Writes out the given message using the optional logger if the info log level is set.
+    ///
+    /// - Parameter message: A closure returning the message to log.
+    public func infoMessage(_ message: @escaping () -> String) {
+        guard case let .some(log) = self else { return }
+        log.infoMessage(message)
+    }
+
+    /// Writes out the given message using the optional logger if the event log level is set.
+    ///
+    /// - Parameter message: An autoclosure returning the message to log.
+    public func eventMessage(_ message: @autoclosure @escaping () -> String) {
+        guard case let .some(log) = self else { return }
+        log.eventMessage(message)
+    }
+
+    /// Writes out the given message using the optional logger if the event log level is set.
+    ///
+    /// - Parameter message: A closure returning the message to log.
+    public func eventMessage(_ message: @escaping () -> String) {
+        guard case let .some(log) = self else { return }
+        log.eventMessage(message)
+    }
+
+    /// Writes out the given message using the optional logger if the warn log level is set.
+    ///
+    /// - Parameter message: An autoclosure returning the message to log.
+    public func warnMessage(_ message: @autoclosure @escaping () -> String) {
+        guard case let .some(log) = self else { return }
+        log.warnMessage(message)
+    }
+
+    /// Writes out the given message using the optional logger if the warn log level is set.
+    ///
+    /// - Parameter message: A closure returning the message to log.
+    public func warnMessage(_ message: @escaping () -> String) {
+        guard case let .some(log) = self else { return }
+        log.warnMessage(message)
+    }
+
+    /// Writes out the given message using the optional logger if the error log level is set.
+    ///
+    /// - Parameter message: An autoclosure returning the message to log.
+    public func errorMessage(_ message: @autoclosure @escaping () -> String) {
+        guard case let .some(log) = self else { return }
+        log.errorMessage(message)
+    }
+
+    /// Writes out the given message using the optional logger if the error log level is set.
+    ///
+    /// - Parameter message: A closure returning the message to log.
+    public func errorMessage(_ message: @escaping () -> String) {
+        guard case let .some(log) = self else { return }
+        log.errorMessage(message)
     }
 }

--- a/Source/Willow.h
+++ b/Source/Willow.h
@@ -1,7 +1,7 @@
 //
 //  Willow.h
 //
-//  Copyright (c) 2015-2017 Nike, Inc. (https://www.nike.com)
+//  Copyright (c) 2015-present Nike, Inc. (https://www.nike.com)
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/Tests/LogLevelTests.swift
+++ b/Tests/LogLevelTests.swift
@@ -1,7 +1,7 @@
 //
 //  LogLevelTests.swift
 //
-//  Copyright (c) 2015-2017 Nike, Inc. (https://www.nike.com)
+//  Copyright (c) 2015-present Nike, Inc. (https://www.nike.com)
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/Tests/LogLevelTests.swift
+++ b/Tests/LogLevelTests.swift
@@ -34,19 +34,19 @@ extension LogLevel {
 }
 
 extension Logger {
-    fileprivate func verbose(message: @autoclosure @escaping () -> String) {
+    fileprivate func verboseMessage(_ message: @autoclosure @escaping () -> String) {
         logMessage(message, with: LogLevel.verbose)
     }
 
-    fileprivate func verbose(message: @escaping () -> String) {
+    fileprivate func verboseMessage(_ message: @escaping () -> String) {
         logMessage(message, with: LogLevel.verbose)
     }
 
-    fileprivate func summary(message: @autoclosure @escaping () -> String) {
+    fileprivate func summaryMessage(_ message: @autoclosure @escaping () -> String) {
         logMessage(message, with: LogLevel.summary)
     }
 
-    fileprivate func summary(message: @escaping () -> String) {
+    fileprivate func summaryMessage(_ message: @escaping () -> String) {
         logMessage(message, with: LogLevel.summary)
     }
 }
@@ -173,25 +173,25 @@ class CustomLogLevelTestCase: XCTestCase {
         let (log, writer) = logger(logLevels: .all)
 
         // When / Then
-        log.verbose { "verbose message" }
+        log.verboseMessage { "verbose message" }
         XCTAssertEqual("verbose message", writer.message ?? "", "Expected message should match actual writer message")
 
-        log.debug { "debug message" }
+        log.debugMessage { "debug message" }
         XCTAssertEqual("debug message", writer.message ?? "", "Expected message should match actual writer message")
 
-        log.info { "info message" }
+        log.infoMessage { "info message" }
         XCTAssertEqual("info message", writer.message ?? "", "Expected message should match actual writer message")
 
-        log.summary { "summary message" }
+        log.summaryMessage { "summary message" }
         XCTAssertEqual("summary message", writer.message ?? "", "Expected message should match actual writer message")
 
-        log.event { "event message" }
+        log.eventMessage { "event message" }
         XCTAssertEqual("event message", writer.message ?? "", "Expected message should match actual writer message")
 
-        log.warn { "warn message" }
+        log.warnMessage { "warn message" }
         XCTAssertEqual("warn message", writer.message ?? "", "Expected message should match actual writer message")
 
-        log.error { "error message" }
+        log.errorMessage { "error message" }
         XCTAssertEqual("error message", writer.message ?? "", "Expected message should match actual writer message")
 
         // Then
@@ -204,25 +204,25 @@ class CustomLogLevelTestCase: XCTestCase {
         let (log, writer) = logger(logLevels: logLevels)
 
         // When / Then
-        log.verbose { "verbose message" }
+        log.verboseMessage { "verbose message" }
         XCTAssertEqual("verbose message", writer.message ?? "", "Expected message should match actual writer message")
 
-        log.debug { "debug message" }
+        log.debugMessage { "debug message" }
         XCTAssertEqual("verbose message", writer.message ?? "", "Expected message should match actual writer message")
 
-        log.info { "info message" }
+        log.infoMessage { "info message" }
         XCTAssertEqual("info message", writer.message ?? "", "Expected message should match actual writer message")
 
-        log.summary { "summary message" }
+        log.summaryMessage { "summary message" }
         XCTAssertEqual("summary message", writer.message ?? "", "Expected message should match actual writer message")
 
-        log.event { "event message" }
+        log.eventMessage { "event message" }
         XCTAssertEqual("summary message", writer.message ?? "", "Expected message should match actual writer message")
 
-        log.warn { "warn message" }
+        log.warnMessage { "warn message" }
         XCTAssertEqual("warn message", writer.message ?? "", "Expected message should match actual writer message")
 
-        log.error { "error message" }
+        log.errorMessage { "error message" }
         XCTAssertEqual("warn message", writer.message ?? "", "Expected message should match actual writer message")
 
         // Then

--- a/Tests/LogModifierTests.swift
+++ b/Tests/LogModifierTests.swift
@@ -1,5 +1,5 @@
 //
-//  ModifierTests.swift
+//  LogModifierTests.swift
 //
 //  Copyright (c) 2015-present Nike, Inc. (https://www.nike.com)
 //

--- a/Tests/LogWriterTests.swift
+++ b/Tests/LogWriterTests.swift
@@ -1,5 +1,5 @@
 //
-//  WriterTests.swift
+//  LogWriterTests.swift
 //
 //  Copyright (c) 2015-present Nike, Inc. (https://www.nike.com)
 //

--- a/Tests/LoggerMessageStringTests.swift
+++ b/Tests/LoggerMessageStringTests.swift
@@ -34,11 +34,11 @@ class SynchronousLoggerLogLevelTestCase: SynchronousLoggerTestCase {
         let (log, writer) = logger(logLevels: .off)
 
         // When
-        log.debug { "" }
-        log.info { "" }
-        log.event { "" }
-        log.warn { "" }
-        log.error { "" }
+        log.debugMessage { "" }
+        log.infoMessage { "" }
+        log.eventMessage { "" }
+        log.warnMessage { "" }
+        log.errorMessage { "" }
 
         // Then
         XCTAssertEqual(writer.actualNumberOfWrites, 0, "Actual number of writes should be 0")
@@ -49,11 +49,11 @@ class SynchronousLoggerLogLevelTestCase: SynchronousLoggerTestCase {
         let (log, writer) = logger(logLevels: .debug)
 
         // When
-        log.debug { "" }
-        log.info { "" }
-        log.event { "" }
-        log.warn { "" }
-        log.error { "" }
+        log.debugMessage { "" }
+        log.infoMessage { "" }
+        log.eventMessage { "" }
+        log.warnMessage { "" }
+        log.errorMessage { "" }
 
         // Then
         XCTAssertEqual(writer.actualNumberOfWrites, 1, "Actual number of writes should be 1")
@@ -64,11 +64,11 @@ class SynchronousLoggerLogLevelTestCase: SynchronousLoggerTestCase {
         let (log, writer) = logger(logLevels: .info)
 
         // When
-        log.debug { "" }
-        log.info { "" }
-        log.event { "" }
-        log.warn { "" }
-        log.error { "" }
+        log.debugMessage { "" }
+        log.infoMessage { "" }
+        log.eventMessage { "" }
+        log.warnMessage { "" }
+        log.errorMessage { "" }
 
         // Then
         XCTAssertEqual(writer.actualNumberOfWrites, 1, "Actual number of writes should be 1")
@@ -79,11 +79,11 @@ class SynchronousLoggerLogLevelTestCase: SynchronousLoggerTestCase {
         let (log, writer) = logger(logLevels: .event)
 
         // When
-        log.debug { "" }
-        log.info { "" }
-        log.event { "" }
-        log.warn { "" }
-        log.error { "" }
+        log.debugMessage { "" }
+        log.infoMessage { "" }
+        log.eventMessage { "" }
+        log.warnMessage { "" }
+        log.errorMessage { "" }
 
         // Then
         XCTAssertEqual(writer.actualNumberOfWrites, 1, "Actual number of writes should be 1")
@@ -94,11 +94,11 @@ class SynchronousLoggerLogLevelTestCase: SynchronousLoggerTestCase {
         let (log, writer) = logger(logLevels: .warn)
 
         // When
-        log.debug { "" }
-        log.info { "" }
-        log.event { "" }
-        log.warn { "" }
-        log.error { "" }
+        log.debugMessage { "" }
+        log.infoMessage { "" }
+        log.eventMessage { "" }
+        log.warnMessage { "" }
+        log.errorMessage { "" }
 
         // Then
         XCTAssertEqual(writer.actualNumberOfWrites, 1, "Actual number of writes should be 1")
@@ -109,11 +109,11 @@ class SynchronousLoggerLogLevelTestCase: SynchronousLoggerTestCase {
         let (log, writer) = logger(logLevels: .error)
 
         // When
-        log.debug { "" }
-        log.info { "" }
-        log.event { "" }
-        log.warn { "" }
-        log.error { "" }
+        log.debugMessage { "" }
+        log.infoMessage { "" }
+        log.eventMessage { "" }
+        log.warnMessage { "" }
+        log.errorMessage { "" }
 
         // Then
         XCTAssertEqual(writer.actualNumberOfWrites, 1, "Actual number of writes should be 1")
@@ -124,11 +124,11 @@ class SynchronousLoggerLogLevelTestCase: SynchronousLoggerTestCase {
         let (log, writer) = logger(logLevels: .all)
 
         // When
-        log.debug { "" }
-        log.info { "" }
-        log.event { "" }
-        log.warn { "" }
-        log.error { "" }
+        log.debugMessage { "" }
+        log.infoMessage { "" }
+        log.eventMessage { "" }
+        log.warnMessage { "" }
+        log.errorMessage { "" }
 
         // Then
         XCTAssertEqual(writer.actualNumberOfWrites, 5, "Actual number of writes should be 5")
@@ -140,11 +140,11 @@ class SynchronousLoggerLogLevelTestCase: SynchronousLoggerTestCase {
         let (log, writer) = logger(logLevels: logLevels)
 
         // When
-        log.debug { "" }
-        log.info { "" }
-        log.event { "" }
-        log.warn { "" }
-        log.error { "" }
+        log.debugMessage { "" }
+        log.infoMessage { "" }
+        log.eventMessage { "" }
+        log.warnMessage { "" }
+        log.errorMessage { "" }
 
         // Then
         XCTAssertEqual(writer.actualNumberOfWrites, 3, "Actual number of writes should be 3")
@@ -155,28 +155,28 @@ class SynchronousLoggerLogLevelTestCase: SynchronousLoggerTestCase {
         let (log, writer) = logger(logLevels: .all)
 
         // When
-        log.debug { () -> String in
-            log.debug { "" }
+        log.debugMessage {
+            log.debugMessage { "" }
             return ""
         }
 
-        log.info { () -> String in
-            log.info { "" }
+        log.infoMessage {
+            log.infoMessage { "" }
             return ""
         }
 
-        log.event { () -> String in
-            log.event { "" }
+        log.eventMessage {
+            log.eventMessage { "" }
             return ""
         }
 
-        log.warn { () -> String in
-            log.warn { "" }
+        log.warnMessage {
+            log.warnMessage { "" }
             return ""
         }
 
-        log.error { () -> String in
-            log.error { "" }
+        log.errorMessage {
+            log.errorMessage { "" }
             return ""
         }
 
@@ -189,11 +189,11 @@ class SynchronousLoggerLogLevelTestCase: SynchronousLoggerTestCase {
         let (log, writer) = logger(logLevels: .debug)
 
         // When
-        log.debug("")
-        log.info("")
-        log.event("")
-        log.warn("")
-        log.error("")
+        log.debugMessage("")
+        log.infoMessage("")
+        log.eventMessage("")
+        log.warnMessage("")
+        log.errorMessage("")
 
         // Then
         XCTAssertEqual(writer.actualNumberOfWrites, 1, "Actual number of writes should be 1")
@@ -204,11 +204,11 @@ class SynchronousLoggerLogLevelTestCase: SynchronousLoggerTestCase {
         let (log, writer) = logger(logLevels: .info)
 
         // When
-        log.debug("")
-        log.info("")
-        log.event("")
-        log.warn("")
-        log.error("")
+        log.debugMessage("")
+        log.infoMessage("")
+        log.eventMessage("")
+        log.warnMessage("")
+        log.errorMessage("")
 
         // Then
         XCTAssertEqual(writer.actualNumberOfWrites, 1, "Actual number of writes should be 1")
@@ -219,11 +219,11 @@ class SynchronousLoggerLogLevelTestCase: SynchronousLoggerTestCase {
         let (log, writer) = logger(logLevels: .event)
 
         // When
-        log.debug("")
-        log.info("")
-        log.event("")
-        log.warn("")
-        log.error("")
+        log.debugMessage("")
+        log.infoMessage("")
+        log.eventMessage("")
+        log.warnMessage("")
+        log.errorMessage("")
 
         // Then
         XCTAssertEqual(writer.actualNumberOfWrites, 1, "Actual number of writes should be 1")
@@ -234,11 +234,11 @@ class SynchronousLoggerLogLevelTestCase: SynchronousLoggerTestCase {
         let (log, writer) = logger(logLevels: .warn)
 
         // When
-        log.debug("")
-        log.info("")
-        log.event("")
-        log.warn("")
-        log.error("")
+        log.debugMessage("")
+        log.infoMessage("")
+        log.eventMessage("")
+        log.warnMessage("")
+        log.errorMessage("")
 
         // Then
         XCTAssertEqual(writer.actualNumberOfWrites, 1, "Actual number of writes should be 1")
@@ -249,11 +249,11 @@ class SynchronousLoggerLogLevelTestCase: SynchronousLoggerTestCase {
         let (log, writer) = logger(logLevels: .error)
 
         // When
-        log.debug("")
-        log.info("")
-        log.event("")
-        log.warn("")
-        log.error("")
+        log.debugMessage("")
+        log.infoMessage("")
+        log.eventMessage("")
+        log.warnMessage("")
+        log.errorMessage("")
 
         // Then
         XCTAssertEqual(writer.actualNumberOfWrites, 1, "Actual number of writes should be 1")
@@ -268,11 +268,11 @@ class AsynchronousLoggerLogLevelTestCase: AsynchronousLoggerTestCase {
         let (log, writer) = logger(logLevels: .off, expectedNumberOfWrites: 0)
 
         // When
-        log.debug { "" }
-        log.info { "" }
-        log.event { "" }
-        log.warn { "" }
-        log.error { "" }
+        log.debugMessage { "" }
+        log.infoMessage { "" }
+        log.eventMessage { "" }
+        log.warnMessage { "" }
+        log.errorMessage { "" }
 
         // This is an interesting test because we have to wait to make sure nothing happened. This makes it
         // very difficult to fullfill the expectation. For now, we are using a dispatch_after that fires
@@ -293,11 +293,11 @@ class AsynchronousLoggerLogLevelTestCase: AsynchronousLoggerTestCase {
         let (log, writer) = logger(logLevels: .debug, expectedNumberOfWrites: 1)
 
         // When
-        log.debug { "" }
-        log.info { "" }
-        log.event { "" }
-        log.warn { "" }
-        log.error { "" }
+        log.debugMessage { "" }
+        log.infoMessage { "" }
+        log.eventMessage { "" }
+        log.warnMessage { "" }
+        log.errorMessage { "" }
 
         waitForExpectations(timeout: timeout, handler: nil)
 
@@ -310,11 +310,11 @@ class AsynchronousLoggerLogLevelTestCase: AsynchronousLoggerTestCase {
         let (log, writer) = logger(logLevels: .info, expectedNumberOfWrites: 1)
 
         // When
-        log.debug { "" }
-        log.info { "" }
-        log.event { "" }
-        log.warn { "" }
-        log.error { "" }
+        log.debugMessage { "" }
+        log.infoMessage { "" }
+        log.eventMessage { "" }
+        log.warnMessage { "" }
+        log.errorMessage { "" }
 
         waitForExpectations(timeout: timeout, handler: nil)
 
@@ -327,11 +327,11 @@ class AsynchronousLoggerLogLevelTestCase: AsynchronousLoggerTestCase {
         let (log, writer) = logger(logLevels: .event, expectedNumberOfWrites: 1)
 
         // When
-        log.debug { "" }
-        log.info { "" }
-        log.event { "" }
-        log.warn { "" }
-        log.error { "" }
+        log.debugMessage { "" }
+        log.infoMessage { "" }
+        log.eventMessage { "" }
+        log.warnMessage { "" }
+        log.errorMessage { "" }
 
         waitForExpectations(timeout: timeout, handler: nil)
 
@@ -344,11 +344,11 @@ class AsynchronousLoggerLogLevelTestCase: AsynchronousLoggerTestCase {
         let (log, writer) = logger(logLevels: .warn, expectedNumberOfWrites: 1)
 
         // When
-        log.debug { "" }
-        log.info { "" }
-        log.event { "" }
-        log.warn { "" }
-        log.error { "" }
+        log.debugMessage { "" }
+        log.infoMessage { "" }
+        log.eventMessage { "" }
+        log.warnMessage { "" }
+        log.errorMessage { "" }
 
         waitForExpectations(timeout: timeout, handler: nil)
 
@@ -361,11 +361,11 @@ class AsynchronousLoggerLogLevelTestCase: AsynchronousLoggerTestCase {
         let (log, writer) = logger(logLevels: .error, expectedNumberOfWrites: 1)
 
         // When
-        log.debug { "" }
-        log.info { "" }
-        log.event { "" }
-        log.warn { "" }
-        log.error { "" }
+        log.debugMessage { "" }
+        log.infoMessage { "" }
+        log.eventMessage { "" }
+        log.warnMessage { "" }
+        log.errorMessage { "" }
 
         waitForExpectations(timeout: timeout, handler: nil)
 
@@ -379,11 +379,11 @@ class AsynchronousLoggerLogLevelTestCase: AsynchronousLoggerTestCase {
         let (log, writer) = logger(logLevels: logLevels, expectedNumberOfWrites: 3)
 
         // When
-        log.debug { "" }
-        log.info { "" }
-        log.event { "" }
-        log.warn { "" }
-        log.error { "" }
+        log.debugMessage { "" }
+        log.infoMessage { "" }
+        log.eventMessage { "" }
+        log.warnMessage { "" }
+        log.errorMessage { "" }
 
         waitForExpectations(timeout: timeout, handler: nil)
 
@@ -396,28 +396,28 @@ class AsynchronousLoggerLogLevelTestCase: AsynchronousLoggerTestCase {
         let (log, writer) = logger(logLevels: .all, expectedNumberOfWrites: 10)
 
         // When
-        log.debug { () -> String in
-            log.debug { "" }
+        log.debugMessage {
+            log.debugMessage { "" }
             return ""
         }
 
-        log.info { () -> String in
-            log.info { "" }
+        log.infoMessage {
+            log.infoMessage { "" }
             return ""
         }
 
-        log.event { () -> String in
-            log.event { "" }
+        log.eventMessage {
+            log.eventMessage { "" }
             return ""
         }
 
-        log.warn { () -> String in
-            log.warn { "" }
+        log.warnMessage {
+            log.warnMessage { "" }
             return ""
         }
 
-        log.error { () -> String in
-            log.error { "" }
+        log.errorMessage {
+            log.errorMessage { "" }
             return ""
         }
 
@@ -437,11 +437,11 @@ class SynchronousLoggerEnabledTestCase: SynchronousLoggerTestCase {
         log.enabled = true
 
         // When
-        log.debug { "" }
-        log.info { "" }
-        log.event { "" }
-        log.warn { "" }
-        log.error { "" }
+        log.debugMessage { "" }
+        log.infoMessage { "" }
+        log.eventMessage { "" }
+        log.warnMessage { "" }
+        log.errorMessage { "" }
 
         // Then
         XCTAssertEqual(writer.actualNumberOfWrites, 5, "Actual number of writes should be equal to 5")
@@ -453,11 +453,11 @@ class SynchronousLoggerEnabledTestCase: SynchronousLoggerTestCase {
         log.enabled = false
 
         // When
-        log.debug { "" }
-        log.info { "" }
-        log.event { "" }
-        log.warn { "" }
-        log.error { "" }
+        log.debugMessage { "" }
+        log.infoMessage { "" }
+        log.eventMessage { "" }
+        log.warnMessage { "" }
+        log.errorMessage { "" }
 
         // Then
         XCTAssertEqual(writer.actualNumberOfWrites, 0, "Actual number of writes should be equal to 0")

--- a/Tests/LoggerMessageStringTests.swift
+++ b/Tests/LoggerMessageStringTests.swift
@@ -1,7 +1,7 @@
 //
 //  LoggerMessageStringTests.swift
 //
-//  Copyright (c) 2015-2017 Nike, Inc. (https://www.nike.com)
+//  Copyright (c) 2015-present Nike, Inc. (https://www.nike.com)
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/Tests/LoggerMessageTests.swift
+++ b/Tests/LoggerMessageTests.swift
@@ -28,9 +28,9 @@ import XCTest
 
 struct TestMessage: LogMessage {
     let name: String
-    let attributes: [String : Any]
+    let attributes: [String: Any]
 
-    init(_ name: String = "", attributes: [String : Any] = [:]) {
+    init(_ name: String = "", attributes: [String: Any] = [:]) {
         self.name = name
         self.attributes = attributes
     }

--- a/Tests/LoggerMessageTests.swift
+++ b/Tests/LoggerMessageTests.swift
@@ -1,7 +1,7 @@
 //
 //  LoggerMessageTests.swift
 //
-//  Copyright (c) 2015-2017 Nike, Inc. (https://www.nike.com)
+//  Copyright (c) 2015-present Nike, Inc. (https://www.nike.com)
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/Tests/LoggerMessageTests.swift
+++ b/Tests/LoggerMessageTests.swift
@@ -174,27 +174,27 @@ class SynchronousLoggerMessageLogLevelTestCase: SynchronousLoggerTestCase {
         let message = TestMessage()
 
         // When
-        log.debug { () -> LogMessage in
+        log.debug {
             log.debug { message }
             return message
         }
 
-        log.info { () -> LogMessage in
+        log.info {
             log.info { message }
             return message
         }
 
-        log.event { () -> LogMessage in
+        log.event {
             log.event { message }
             return message
         }
 
-        log.warn { () -> LogMessage in
+        log.warn {
             log.warn { message }
             return message
         }
 
-        log.error { () -> LogMessage in
+        log.error {
             log.error { message }
             return message
         }
@@ -428,27 +428,27 @@ class AsynchronousLoggerMessageLogLevelTestCase: AsynchronousLoggerTestCase {
         let message = TestMessage()
 
         // When
-        log.debug { () -> LogMessage in
+        log.debug {
             log.debug { TestMessage() }
             return message
         }
 
-        log.info { () -> LogMessage in
+        log.info {
             log.info { TestMessage() }
             return message
         }
 
-        log.event { () -> LogMessage in
+        log.event {
             log.event { TestMessage() }
             return message
         }
 
-        log.warn { () -> LogMessage in
+        log.warn {
             log.warn { TestMessage() }
             return message
         }
 
-        log.error { () -> LogMessage in
+        log.error {
             log.error { TestMessage() }
             return message
         }

--- a/Tests/LoggerTests.swift
+++ b/Tests/LoggerTests.swift
@@ -160,11 +160,11 @@ class SynchronousLoggerMultiModifierTestCase: SynchronousLoggerTestCase {
         let (log, writer) = logger(modifiers: modifiers)
 
         // When
-        log.debug { self.message }
-        log.info { self.message }
-        log.event { self.message }
-        log.warn { self.message }
-        log.error { self.message }
+        log.debugMessage { self.message }
+        log.infoMessage { self.message }
+        log.eventMessage { self.message }
+        log.warnMessage { self.message }
+        log.errorMessage { self.message }
 
         // Then
         XCTAssertEqual(writer.actualNumberOfWrites, 5, "Actual number of writes should be 5")
@@ -187,11 +187,11 @@ class SynchronousLoggerMultiWriterTestCase: SynchronousLoggerTestCase {
         let log = logger(writers: writers)
 
         // When
-        log.debug { self.message }
-        log.info { self.message }
-        log.event { self.message }
-        log.warn { self.message }
-        log.error { self.message }
+        log.debugMessage { self.message }
+        log.infoMessage { self.message }
+        log.eventMessage { self.message }
+        log.warnMessage { self.message }
+        log.errorMessage { self.message }
 
         // Then
         XCTAssertEqual(writer1.actualNumberOfWrites, 5, "writer 1 actual number of writes should be 5")

--- a/Tests/LoggerTests.swift
+++ b/Tests/LoggerTests.swift
@@ -1,7 +1,7 @@
 //
 //  LoggerTests.swift
 //
-//  Copyright (c) 2015-2017 Nike, Inc. (https://www.nike.com)
+//  Copyright (c) 2015-present Nike, Inc. (https://www.nike.com)
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/Tests/LoggerTests.swift
+++ b/Tests/LoggerTests.swift
@@ -27,9 +27,9 @@ import Willow
 import XCTest
 
 #if os(iOS) || os(tvOS) || os(watchOS)
-    import UIKit
+import UIKit
 #elseif os(macOS)
-    import Cocoa
+import Cocoa
 #endif
 
 // MARK: Test Helpers

--- a/Tests/ModifierTests.swift
+++ b/Tests/ModifierTests.swift
@@ -1,7 +1,7 @@
 //
 //  ModifierTests.swift
 //
-//  Copyright (c) 2015-2017 Nike, Inc. (https://www.nike.com)
+//  Copyright (c) 2015-present Nike, Inc. (https://www.nike.com)
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/Tests/WriterTests.swift
+++ b/Tests/WriterTests.swift
@@ -1,7 +1,7 @@
 //
 //  WriterTests.swift
 //
-//  Copyright (c) 2015-2017 Nike, Inc. (https://www.nike.com)
+//  Copyright (c) 2015-present Nike, Inc. (https://www.nike.com)
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/Willow.podspec
+++ b/Willow.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name = 'Willow'
-  s.version = '4.0.0'
+  s.version = '5.0.0'
   s.license = 'MIT'
   s.summary = 'A powerful, yet lightweight logging library written in Swift.'
   s.homepage = 'https://github.com/Nike-Inc/Willow'

--- a/Willow.xcodeproj/project.pbxproj
+++ b/Willow.xcodeproj/project.pbxproj
@@ -101,6 +101,7 @@
 		4CD142361F572F6C002D6006 /* Willow 2.0 Migration Guide.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; name = "Willow 2.0 Migration Guide.md"; path = "Documentation/Willow 2.0 Migration Guide.md"; sourceTree = "<group>"; };
 		4CD142371F572F6C002D6006 /* Willow 3.0 Migration Guide.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; name = "Willow 3.0 Migration Guide.md"; path = "Documentation/Willow 3.0 Migration Guide.md"; sourceTree = "<group>"; };
 		4CD142381F572F6C002D6006 /* Willow 4.0 Migration Guide.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; name = "Willow 4.0 Migration Guide.md"; path = "Documentation/Willow 4.0 Migration Guide.md"; sourceTree = "<group>"; };
+		4CF3EBD71F72FB5D00ECFA06 /* Willow 5.0 Migration Guide.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; name = "Willow 5.0 Migration Guide.md"; path = "Documentation/Willow 5.0 Migration Guide.md"; sourceTree = "<group>"; };
 		4CF89C8B1A6E2F60001BFDE1 /* Willow.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Willow.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		4CF89C951A6E2F60001BFDE1 /* WillowTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = WillowTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		4CFE82991A6C484A0002868E /* Willow.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Willow.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -224,6 +225,7 @@
 				4CD142361F572F6C002D6006 /* Willow 2.0 Migration Guide.md */,
 				4CD142371F572F6C002D6006 /* Willow 3.0 Migration Guide.md */,
 				4CD142381F572F6C002D6006 /* Willow 4.0 Migration Guide.md */,
+				4CF3EBD71F72FB5D00ECFA06 /* Willow 5.0 Migration Guide.md */,
 			);
 			name = "Migration Guides";
 			sourceTree = "<group>";

--- a/Willow.xcodeproj/project.pbxproj
+++ b/Willow.xcodeproj/project.pbxproj
@@ -8,10 +8,10 @@
 
 /* Begin PBXBuildFile section */
 		321F2DF335043A818DBEC881 /* (null) in Frameworks */ = {isa = PBXBuildFile; };
-		4C0CE38D1CFF3FB600D57B03 /* WriterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C0CE38C1CFF3FB600D57B03 /* WriterTests.swift */; };
-		4C0CE38E1CFF3FB600D57B03 /* WriterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C0CE38C1CFF3FB600D57B03 /* WriterTests.swift */; };
-		4C0CE38F1CFF3FB600D57B03 /* WriterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C0CE38C1CFF3FB600D57B03 /* WriterTests.swift */; };
-		4C1BBA6B1A6C518800D39EE1 /* ModifierTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C1BBA691A6C518800D39EE1 /* ModifierTests.swift */; };
+		4C0CE38D1CFF3FB600D57B03 /* LogWriterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C0CE38C1CFF3FB600D57B03 /* LogWriterTests.swift */; };
+		4C0CE38E1CFF3FB600D57B03 /* LogWriterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C0CE38C1CFF3FB600D57B03 /* LogWriterTests.swift */; };
+		4C0CE38F1CFF3FB600D57B03 /* LogWriterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C0CE38C1CFF3FB600D57B03 /* LogWriterTests.swift */; };
+		4C1BBA6B1A6C518800D39EE1 /* LogModifierTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C1BBA691A6C518800D39EE1 /* LogModifierTests.swift */; };
 		4C1BBA6C1A6C518800D39EE1 /* LoggerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C1BBA6A1A6C518800D39EE1 /* LoggerTests.swift */; };
 		4C83FB2D1AEC1959003FEA49 /* LogLevel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C83FB2C1AEC1959003FEA49 /* LogLevel.swift */; };
 		4C83FB2E1AEC1959003FEA49 /* LogLevel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C83FB2C1AEC1959003FEA49 /* LogLevel.swift */; };
@@ -22,7 +22,7 @@
 		4C88353A1C82530300F70419 /* LogWriter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4CA86F671AEC466A005E6475 /* LogWriter.swift */; };
 		4C88353B1C82530600F70419 /* Willow.h in Headers */ = {isa = PBXBuildFile; fileRef = 4CA75D421A6C493800275DC5 /* Willow.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		4C88353C1C82530F00F70419 /* LogLevelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4CBE850B1AEA2EFA006A1205 /* LogLevelTests.swift */; };
-		4C88353D1C82530F00F70419 /* ModifierTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C1BBA691A6C518800D39EE1 /* ModifierTests.swift */; };
+		4C88353D1C82530F00F70419 /* LogModifierTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C1BBA691A6C518800D39EE1 /* LogModifierTests.swift */; };
 		4C88353E1C82530F00F70419 /* LoggerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C1BBA6A1A6C518800D39EE1 /* LoggerTests.swift */; };
 		4CA33F341B7556FC0047C307 /* LogModifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4CA86F641AEC465E005E6475 /* LogModifier.swift */; };
 		4CA33F351B7556FC0047C307 /* Logger.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4CA86F611AEC4654005E6475 /* Logger.swift */; };
@@ -38,7 +38,7 @@
 		4CA86F691AEC466A005E6475 /* LogWriter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4CA86F671AEC466A005E6475 /* LogWriter.swift */; };
 		4CBE850E1AEA2F3D006A1205 /* LogLevelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4CBE850B1AEA2EFA006A1205 /* LogLevelTests.swift */; };
 		4CBE850F1AEA2F3E006A1205 /* LogLevelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4CBE850B1AEA2EFA006A1205 /* LogLevelTests.swift */; };
-		4CC837781A6E347700B31851 /* ModifierTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C1BBA691A6C518800D39EE1 /* ModifierTests.swift */; };
+		4CC837781A6E347700B31851 /* LogModifierTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C1BBA691A6C518800D39EE1 /* LogModifierTests.swift */; };
 		4CC837791A6E347A00B31851 /* LoggerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C1BBA6A1A6C518800D39EE1 /* LoggerTests.swift */; };
 		4CF89C961A6E2F60001BFDE1 /* Willow.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 4CF89C8B1A6E2F60001BFDE1 /* Willow.framework */; };
 		4CF89CA41A6E2F9A001BFDE1 /* Willow.h in Headers */ = {isa = PBXBuildFile; fileRef = 4CA75D421A6C493800275DC5 /* Willow.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -80,9 +80,9 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
-		4C0CE38C1CFF3FB600D57B03 /* WriterTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = WriterTests.swift; sourceTree = "<group>"; };
+		4C0CE38C1CFF3FB600D57B03 /* LogWriterTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LogWriterTests.swift; sourceTree = "<group>"; };
 		4C0CE3981CFF941900D57B03 /* Info-tvOS.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = "Info-tvOS.plist"; sourceTree = "<group>"; };
-		4C1BBA691A6C518800D39EE1 /* ModifierTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ModifierTests.swift; sourceTree = "<group>"; };
+		4C1BBA691A6C518800D39EE1 /* LogModifierTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LogModifierTests.swift; sourceTree = "<group>"; };
 		4C1BBA6A1A6C518800D39EE1 /* LoggerTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LoggerTests.swift; sourceTree = "<group>"; };
 		4C83FB2C1AEC1959003FEA49 /* LogLevel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LogLevel.swift; sourceTree = "<group>"; };
 		4C88351E1C82506600F70419 /* Willow.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Willow.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -201,8 +201,8 @@
 				557DA8351F3E1A9C005BC651 /* LoggerMessageTests.swift */,
 				4C1BBA6A1A6C518800D39EE1 /* LoggerTests.swift */,
 				4CBE850B1AEA2EFA006A1205 /* LogLevelTests.swift */,
-				4C1BBA691A6C518800D39EE1 /* ModifierTests.swift */,
-				4C0CE38C1CFF3FB600D57B03 /* WriterTests.swift */,
+				4C1BBA691A6C518800D39EE1 /* LogModifierTests.swift */,
+				4C0CE38C1CFF3FB600D57B03 /* LogWriterTests.swift */,
 				557DA8401F3E1DB2005BC651 /* Supporting Files */,
 			);
 			path = Tests;
@@ -574,8 +574,8 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				4C0CE38F1CFF3FB600D57B03 /* WriterTests.swift in Sources */,
-				4C88353D1C82530F00F70419 /* ModifierTests.swift in Sources */,
+				4C0CE38F1CFF3FB600D57B03 /* LogWriterTests.swift in Sources */,
+				4C88353D1C82530F00F70419 /* LogModifierTests.swift in Sources */,
 				4C88353C1C82530F00F70419 /* LogLevelTests.swift in Sources */,
 				4C88353E1C82530F00F70419 /* LoggerTests.swift in Sources */,
 				557DA8381F3E1A9C005BC651 /* LoggerMessageTests.swift in Sources */,
@@ -611,9 +611,9 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				4C0CE38E1CFF3FB600D57B03 /* WriterTests.swift in Sources */,
+				4C0CE38E1CFF3FB600D57B03 /* LogWriterTests.swift in Sources */,
 				4CBE850F1AEA2F3E006A1205 /* LogLevelTests.swift in Sources */,
-				4CC837781A6E347700B31851 /* ModifierTests.swift in Sources */,
+				4CC837781A6E347700B31851 /* LogModifierTests.swift in Sources */,
 				4CC837791A6E347A00B31851 /* LoggerTests.swift in Sources */,
 				557DA8371F3E1A9C005BC651 /* LoggerMessageTests.swift in Sources */,
 				557DA8331F3E1954005BC651 /* LoggerMessageStringTests.swift in Sources */,
@@ -636,10 +636,10 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				4C0CE38D1CFF3FB600D57B03 /* WriterTests.swift in Sources */,
+				4C0CE38D1CFF3FB600D57B03 /* LogWriterTests.swift in Sources */,
 				4CBE850E1AEA2F3D006A1205 /* LogLevelTests.swift in Sources */,
 				4C1BBA6C1A6C518800D39EE1 /* LoggerTests.swift in Sources */,
-				4C1BBA6B1A6C518800D39EE1 /* ModifierTests.swift in Sources */,
+				4C1BBA6B1A6C518800D39EE1 /* LogModifierTests.swift in Sources */,
 				557DA8361F3E1A9C005BC651 /* LoggerMessageTests.swift in Sources */,
 				557DA8321F3E1954005BC651 /* LoggerMessageStringTests.swift in Sources */,
 			);


### PR DESCRIPTION
This PR fixes an issue we identified in the Willow 4.0.0 release where the escaping closure APIs are ambiguous when the closure is multiline. The compiler can't infer what the return type of the closure is unfortunately. You can declare the return type of the closure to fix the ambiguity error, but that's less than ideal.

> See the migration guide for examples of the issue.

These changes fix the ambiguity by changing the log message string APIs to include the `Message` suffix. This fixes the ambiguity properly. The only question is whether this is the best way to name the APIs. I think this makes the usage the most readable.

```swift
log.debug(Message.requestStarted)
log.debugMessage("This is a test message")
```

I'm open to suggestions if anyone thinks there's a better way. If someone can come up with a backwards compatible solution that doesn't require declaring the return type to the compiler, I'm all ears.