### PR TITLE
Deprecate Optional<Logger> extensions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,9 +29,21 @@ All notable changes to this project will be documented in this file.
 
 ## Unreleased
 
+#### Added
+
+- A `Logger.disabled` static variable that can be assigned to a `Logger` variable. This `Logger` will not write any messages sent to it.
+
 #### Updated
 
 - The Xcode workspace to be compatible with Xcode 10 and Swift 4.2.
+
+#### Deprecated
+
+- The `Optional<Logger>` extensions are now deprecated. Use a non-optional `Logger` variable: `var log: Logger? = nil` → `var log: Logger = .disabled`.
+
+#### Removed
+
+#### Fixed
 
 ---
 

--- a/Example/Frameworks/Database/Logger.swift
+++ b/Example/Frameworks/Database/Logger.swift
@@ -62,8 +62,7 @@ extension Optional where Wrapped == Logger {
 // MARK: -
 
 /// The single `Logger` instance used throughout Database.
-/// Note that the extension for Optional<Logger> allows for the safe use of `log` without unwrapping.
-public var log: Logger?
+public var log: Logger = .disabled
 
 /// Message type used by the Database framework.
 /// With this implementation you would have an enum case for each distinct message to be written.

--- a/Example/Frameworks/WebServices/Logger.swift
+++ b/Example/Frameworks/WebServices/Logger.swift
@@ -26,8 +26,7 @@ import Foundation
 import Willow
 
 /// The single `Logger` instance used throughout WebServices.
-/// Note that the extension for Optional<Logger> allows for the safe use of `log` without unwrapping.
-public var log: Logger?
+public var log: Logger = .disabled
 
 /// Message type used by the WebServices framework.
 /// With this implementation you would have an enum case for each distinct message to be written.

--- a/Example/iOS Example/WillowConfiguration.swift
+++ b/Example/iOS Example/WillowConfiguration.swift
@@ -28,7 +28,7 @@ import UIKit
 import WebServices
 import Willow
 
-var log: Logger!
+var log: Logger = .disabled
 
 struct WillowConfiguration {
 

--- a/Source/Logger.swift
+++ b/Source/Logger.swift
@@ -50,6 +50,9 @@ open class Logger {
 
    // MARK: - Properties
 
+    /// A logger that does not output any messages to writers.
+    public static let disabled: Logger = NoOpLogger()
+
     /// Controls whether to allow log messages to be sent to the writers.
     open var enabled = true
 
@@ -270,10 +273,19 @@ open class Logger {
         writers.forEach { $0.writeMessage(message, logLevel: logLevel) }
     }
 
-    // MARK: - Private - Log Message Helpers
-
     private func logMessage(_ message: LogMessage, with logLevel: LogLevel) {
         writers.forEach { $0.writeMessage(message, logLevel: logLevel) }
+    }
+
+    // MARK: - Private - No-Op Logger
+
+    private final class NoOpLogger: Logger {
+        init() {
+            super.init(logLevels: .off, writers: [])
+            enabled = false
+        }
+
+        override func logMessage(_ message: @escaping () -> String, with logLevel: LogLevel) {}
     }
 }
 
@@ -281,6 +293,7 @@ open class Logger {
 
 /// This allows for the use of a `Logger?` variable without the calling code needing to
 /// guard or optionally unwrap before using the log.
+@available(*, deprecated: 5.1.0, message: "Use a non-optional `Logger` variable")
 extension Optional where Wrapped == Logger {
     /// Writes out the given message using the optional logger if the debug log level is set.
     ///


### PR DESCRIPTION
Deprecates `Optional<Logger>` extensions.

This encourage the use of non-optional log `var`s. Which can be assigned to `.disabled`.
This mimics the [OSLog API](https://developer.apple.com/documentation/os/oslog/2863695-disabled).

The migration is simple: `var log: Logger?` → `var log: Logger = .disabled`.