### PR TITLE
Update the podspec swift version to 4.2

### DIFF
--- a/Willow.podspec
+++ b/Willow.podspec
@@ -9,7 +9,7 @@ Pod::Spec.new do |s|
 
   s.source = { :git => 'https://github.com/Nike-Inc/Willow.git', :tag => s.version }
   s.source_files = 'Source/*.swift'
-  s.swift_version = '4.0'
+  s.swift_version = '4.2'
 
   s.ios.deployment_target = '9.0'
   s.osx.deployment_target = '10.11'


### PR DESCRIPTION
The enabled compiling the Willow pod with Swift 4.2 when using Xcode 10, and falls back to Swift 4.1 on Xcode 9