### PR TITLE
Overridable OSLogLevel mapping

### DIFF
--- a/Source/LogWriter.swift
+++ b/Source/LogWriter.swift
@@ -179,7 +179,12 @@ open class OSLogWriter: LogModifierWriter {
         os_log("%@", log: log, type: type, message)
     }
 
-    private func logType(forLogLevel logLevel: LogLevel) -> OSLogType {
+    /// Returns the `OSLogType` to use for the specified `LogLevel`.
+    ///
+    /// - Parameter logLevel: The level to be map to a `OSLogType`.
+    ///
+    /// - Returns: An `OSLogType` corresponding to the `LogLevel`.
+    open func logType(forLogLevel logLevel: LogLevel) -> OSLogType {
         switch logLevel {
         case LogLevel.debug: return .debug
         case LogLevel.info:  return .info

--- a/Source/LogWriter.swift
+++ b/Source/LogWriter.swift
@@ -188,7 +188,7 @@ open class OSLogWriter: LogModifierWriter {
         switch logLevel {
         case LogLevel.debug: return .debug
         case LogLevel.info:  return .info
-        case LogLevel.warn:  return .error
+        case LogLevel.warn:  return .default
         case LogLevel.error: return .error
         default:             return .default
         }


### PR DESCRIPTION
Addresses [Issue #45 OSLogWriter sends os logs with same type for both warn and error levels]( https://github.com/Nike-Inc/Willow/issues/45).

* Opens `OSLogWriter`'s `logType(forLogLevel:)` to allow overriding in subclasses
* Adjusts the default mapping of `LogLevel.warn` to a `OSLogType`. See Issue #45 for the reasoning