### PR TITLE
add  flag for OSLogWriter to retain log in release mode

### DIFF
--- a/Source/LogWriter.swift
+++ b/Source/LogWriter.swift
@@ -130,6 +130,9 @@ open class ConsoleWriter: LogModifierWriter {
 open class OSLogWriter: LogModifierWriter {
     public let subsystem: String
     public let category: String
+    public let preserve: Bool
+    private let format: StaticString
+    
 
     /// Array of modifiers that the writer should execute (in order) on incoming messages.
     public let modifiers: [LogModifier]
@@ -141,10 +144,12 @@ open class OSLogWriter: LogModifierWriter {
     /// - Parameters:
     ///   - subsystem: The subsystem.
     ///   - category:  The category.
-    public init(subsystem: String, category: String, modifiers: [LogModifier] = []) {
+    public init(subsystem: String, category: String, modifiers: [LogModifier] = [], preserve: Bool = true) {
         self.subsystem = subsystem
         self.category = category
         self.modifiers = modifiers
+        self.preserve = preserve
+        self.format = preserve ? "%{public}@" :"%@"
         self.log = OSLog(subsystem: subsystem, category: category)
     }
 
@@ -160,7 +165,7 @@ open class OSLogWriter: LogModifierWriter {
         let message = modifyMessage(message, logLevel: logLevel)
         let type = logType(forLogLevel: logLevel)
 
-        os_log("%@", log: log, type: type, message)
+        os_log(format, log: log, type: type, message)
     }
 
     /// Writes the breadrumb to the `OSLog` using the `os_log` function.
@@ -175,7 +180,7 @@ open class OSLogWriter: LogModifierWriter {
         let message = modifyMessage("\(message.name): \(message.attributes)", logLevel: logLevel)
         let type = logType(forLogLevel: logLevel)
 
-        os_log("%@", log: log, type: type, message)
+        os_log(format, log: log, type: type, message)
     }
 
     /// Returns the `OSLogType` to use for the specified `LogLevel`.

--- a/Tests/LogModifierTests.swift
+++ b/Tests/LogModifierTests.swift
@@ -34,7 +34,7 @@ class TimestampModifierTestCase: XCTestCase {
         let logLevels: [LogLevel] = [.error, .warn, .event, .info, .debug]
 
         // When
-        var actualMessages = logLevels.map { modifier.modifyMessage(message, with: $0) }
+        let actualMessages = logLevels.map { modifier.modifyMessage(message, with: $0) }
 
         // Then
         for (index, _) in logLevels.enumerated() {


### PR DESCRIPTION
as [os_log document](https://developer.apple.com/documentation/os/logging?language=swift#1682416) pointed, os_log will cover log as `<private>` when reviewed from console while in release mode
this option will give developer the right on whether to hide message on release-mode