### PR TITLE
Proposal: Bump swift tools, macos version

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.0
+// swift-tools-version:5.3
 //
 //  Package.swift
 //
@@ -28,7 +28,7 @@ import PackageDescription
 let package = Package(
     name: "Willow",
     platforms: [
-        .macOS(.v10_12),
+        .macOS(.v10_15),
         .iOS(.v10),
         .tvOS(.v10),
         .watchOS(.v3)


### PR DESCRIPTION
This is a proposal to bump minimum support up to v10.15 for macOS to enable catalyst era compilation.
Additionally: SPM breaks when using Xcode 12, this is the fix.