### PR TITLE
Suggesting converting private to fileprivate to avoid inaccessible error

### DIFF
--- a/README.md
+++ b/README.md
@@ -483,7 +483,7 @@ First, you must create a `LogLevel` extension and add your custom values.
 
 ```swift
 extension LogLevel {
-    private static var verbose = LogLevel(rawValue: 0b00000000_00000000_00000001_00000000)
+    fileprivate static var verbose = LogLevel(rawValue: 0b00000000_00000000_00000001_00000000)
 }
 ```
 


### PR DESCRIPTION
Due to private level restriction, the following code causes `verbose` defined in `LogLevel`, to be inaccessible in `Logger`. At least it should be made `fileprivate` so the logger extension can access it if defined in the same file. The other option is a public protection level.

```
extension LogLevel {
    private static var verbose = LogLevel(rawValue: 0b00000000_00000000_00000001_00000000)
}

extension Logger {
    public func verboseMessage(_ message: @autoclosure @escaping () -> String) {
    	logMessage(message, with: .verbose)
    }

    public func verboseMessage(_ message: @escaping () -> String) {
    	logMessage(message, with: .verbose)
    }
}
``` 