### PR TITLE
Log filters & Runtime log level change support

### DIFF
--- a/Example/iOS Example.xcodeproj/xcshareddata/xcschemes/iOS Example.xcscheme
+++ b/Example/iOS Example.xcodeproj/xcshareddata/xcschemes/iOS Example.xcscheme
@@ -27,8 +27,6 @@
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       shouldUseLaunchSchemeArgsEnv = "YES">
-      <Testables>
-      </Testables>
       <MacroExpansion>
          <BuildableReference
             BuildableIdentifier = "primary"
@@ -38,8 +36,8 @@
             ReferencedContainer = "container:iOS Example.xcodeproj">
          </BuildableReference>
       </MacroExpansion>
-      <AdditionalOptions>
-      </AdditionalOptions>
+      <Testables>
+      </Testables>
    </TestAction>
    <LaunchAction
       buildConfiguration = "Debug"
@@ -61,8 +59,6 @@
             ReferencedContainer = "container:iOS Example.xcodeproj">
          </BuildableReference>
       </BuildableProductRunnable>
-      <AdditionalOptions>
-      </AdditionalOptions>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Release"

--- a/Example/iOS Example/ViewController.swift
+++ b/Example/iOS Example/ViewController.swift
@@ -73,6 +73,23 @@ class ViewController: UIViewController {
 
     private func setUpSections() {
         sections = [
+            Section(title: "Log Filtering", items: [
+                Item(title: "Log level is set to: [\(logLevelFilters[logLevelIndex])] (tap to cycle)", action: { [weak self] in
+                    guard let self else { return }
+
+                    // cycle through log levels
+                    self.logLevelIndex = (self.logLevelIndex + 1).remainderReportingOverflow(dividingBy: self.logLevelFilters.count).partialValue
+
+                    let logLevel = LogLevel.minimum(self.logLevelFilters[self.logLevelIndex])
+                    log.setLogLevels(logLevel)
+                    WebServices.log.setLogLevels(logLevel)
+                    Database.log.setLogLevels(logLevel)
+
+                    // reload the rows so this section is re-rendered
+                    self.setUpSections()
+                    self.tableView.reloadData()
+                })
+            ]),
             Section(
                 title: "Example App",
                 items: [
@@ -208,6 +225,16 @@ class ViewController: UIViewController {
             )
         ]
     }
+
+    private var logLevelIndex = 0
+    private var logLevelFilters: [LogLevel] = [
+        .all,
+        .debug,
+        .info,
+        .event,
+        .warn,
+        .error
+    ]
 
     private func setUpTableView() {
         tableView = {

--- a/Example/iOS Example/WillowConfiguration.swift
+++ b/Example/iOS Example/WillowConfiguration.swift
@@ -114,6 +114,7 @@ struct WillowConfiguration {
             logLevels: webServicesLogLevels,
             executionMethod: executionMethod
         )
+        WebServices.log.addFilter(HTTPStatusCodeFilter(statusCodeToIgnore: 200))
     }
 
     private static func createLogger(
@@ -135,5 +136,28 @@ struct WillowConfiguration {
 private struct ServiceSDK {
     static func recordBreadcrumb(_ message: String, attributes: [String: Any]) {
         // Implement me...
+    }
+}
+
+// An example of a filter that can exclude certain logs
+struct HTTPStatusCodeFilter: LogFilter {
+    let statusCodeToIgnore: Int
+
+    init(statusCodeToIgnore: Int) {
+        self.statusCodeToIgnore = statusCodeToIgnore
+    }
+
+    func shouldInclude(_ logMessage: Willow.LogMessage, level: Willow.LogLevel) -> Bool {
+        if let responseCode = logMessage.attributes["response_code"] as? Int {
+            print("Ignored: \(logMessage.name), \(logMessage.attributes)")
+            return responseCode != statusCodeToIgnore
+        }
+
+        return true
+    }
+
+    func shouldInclude(_ message: String, level: Willow.LogLevel) -> Bool {
+        // string messages don't have the metadata we use to filter
+        true
     }
 }

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ Willow is a powerful, yet lightweight logging library written in Swift.
     - [Creating Custom Log Levels](#creating-custom-log-levels)
     - [Shared Loggers between Frameworks](#shared-loggers-between-frameworks)
     - [Multiple Loggers, One Queue](#multiple-loggers-one-queue)
+    - [Changing the log level at runtime](#changing-log-levels-at-runtime)
 - [FAQ](#faq)
 - [License](#license)
 - [Creators](#creators)
@@ -575,6 +576,24 @@ Math.log = Logger(
 `Willow` is a very lightweight library, but its flexibility allows it to become very powerful if you so wish.
 
 ---
+
+
+### Changing log levels at runtime
+
+It can be advantageous in DEBUG and ADHOC builds to allow testers to change the log level to include messages
+that would otherwise be too noisy to include by default.
+
+You can change the log level at runtime by calling `logger.setLogLevels(...)`. Note that this is passed an OptionSet,
+so you need to include all of the log levels you want to include.
+
+If you are using the default set of options, you can use the `.minimum` helper method to include all levels above
+a given log level. For instance, to include `.info` and above:
+
+```swift
+logger.setLogLevels(.minimum(.info))
+```
+
+This method is not supported if you are using custom log levels.
 
 ## FAQ
 

--- a/README.md
+++ b/README.md
@@ -591,7 +591,7 @@ Here is an example of a filter that can conditionally exclude noisy logs for an 
 
 ```swift
 struct AnalyticsLogFilter: LogFilter {
-    var name: String { "analytics" }
+    let name = "analytics"
     
     func shouldInclude(_ message: LogMessage, logLevel: LogLevel) -> Bool {
         // only consider those with a given attribute

--- a/Source/LogFilter.swift
+++ b/Source/LogFilter.swift
@@ -29,7 +29,7 @@ import Foundation
 ///
 /// The canonical default implementation of this is the ``LogLevelFilter``, which will filter out messages that do
 /// not meet the minimum specified log level.
-public protocol LogFilter {
+public protocol LogFilter: Hashable {
     /// An optional identifier to define if you need to remove this log filter later. Defaults to a randomly generated value.
     var name: String { get }
 
@@ -50,4 +50,12 @@ public protocol LogFilter {
 
 public extension LogFilter {
     var name: String { UUID().uuidString }
+
+    static func == (lhs: Self, rhs: Self) -> Bool {
+        lhs.name == rhs.name
+    }
+
+    func hash(into hasher: inout Hasher) {
+        hasher.combine(name)
+    }
 }

--- a/Source/LogFilter.swift
+++ b/Source/LogFilter.swift
@@ -26,9 +26,6 @@ import Foundation
 
 /// The ``LogFilter`` protocol defines the requirements to add your own dynamic filters to allow your own code to
 /// decide to filter out (i.e. not log) certain types of log messages based on criteria you define.
-///
-/// The canonical default implementation of this is the ``LogLevelFilter``, which will filter out messages that do
-/// not meet the minimum specified log level.
 public protocol LogFilter: Hashable {
     /// An optional identifier to define if you need to remove this log filter later. Defaults to a randomly generated value.
     var name: String { get }

--- a/Source/LogFilter.swift
+++ b/Source/LogFilter.swift
@@ -35,16 +35,16 @@ public protocol LogFilter: Hashable {
 
     /// Determines if a log message should be emitted.
     /// - Parameters:
-    ///   - logMessage: A log message struct
-    ///   - level: The log level of the message
-    /// - Returns: true if the log message should be included
+    ///   - logMessage: A log message struct.
+    ///   - level: The log level of the message.
+    /// - Returns: true if the log message should be included.
     func shouldInclude(_ logMessage: LogMessage, level: LogLevel) -> Bool
 
     /// Determines if a log message should be emitted.
     /// - Parameters:
-    ///   - logMessage: A log message string
-    ///   - level: The log level of the message
-    /// - Returns: true if the log message should be included
+    ///   - logMessage: A log message string.
+    ///   - level: The log level of the message.
+    /// - Returns: true if the log message should be included.
     func shouldInclude(_ message: String, level: LogLevel) -> Bool
 }
 

--- a/Source/LogFilter.swift
+++ b/Source/LogFilter.swift
@@ -1,0 +1,53 @@
+//
+//  LogModifier.swift
+//
+//  Copyright (c) 2015-present Nike, Inc. (https://www.nike.com)
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+//
+
+import Foundation
+
+/// The ``LogFilter`` protocol defines the requirements to add your own dynamic filters to allow your own code to
+/// decide to filter out (i.e. not log) certain types of log messages based on criteria you define.
+///
+/// The canonical default implementation of this is the ``LogLevelFilter``, which will filter out messages that do
+/// not meet the minimum specified log level.
+public protocol LogFilter {
+    /// An optional identifier to define if you need to remove this log filter later. Defaults to a randomly generated value.
+    var name: String { get }
+
+    /// Determines if a log message should be emitted.
+    /// - Parameters:
+    ///   - logMessage: A log message struct
+    ///   - level: The log level of the message
+    /// - Returns: true if the log message should be included
+    func shouldInclude(_ logMessage: LogMessage, level: LogLevel) -> Bool
+
+    /// Determines if a log message should be emitted.
+    /// - Parameters:
+    ///   - logMessage: A log message string
+    ///   - level: The log level of the message
+    /// - Returns: true if the log message should be included
+    func shouldInclude(_ message: String, level: LogLevel) -> Bool
+}
+
+public extension LogFilter {
+    var name: String { UUID().uuidString }
+}

--- a/Source/LogLevel.swift
+++ b/Source/LogLevel.swift
@@ -66,6 +66,23 @@ public struct LogLevel: OptionSet, Equatable, Hashable {
     /// Creates a new default `.all` instance with a bitmask where all bits equal are equal to `1`.
     public static let all = LogLevel(rawValue: allBitmask)
 
+    /// Returns a mask including the minimum log level and above.
+    /// - Parameter minLevel: The minimum ``LogLevel`` to include. Passing in a mask with more than one flag set results in undefined behavior.
+    /// - Returns: A new log level mask.
+    public static func minimum(_ minLevel: LogLevel) -> LogLevel {
+        switch minLevel {
+        case .all, .debug: return .all
+        case .info: return [.info, .event, .warn, .error]
+        case .event: return [.event, .warn, .error]
+        case .warn: return [.warn, .error]
+        case .error: return .error
+        case .off: return []
+        default:
+            // calling this with multiple levels defined is not recommended
+            return minimum(.info)
+        }
+    }
+
     // MARK: Initialization Methods
 
     /// Creates a log level instance with the given raw value.

--- a/Source/Logger.swift
+++ b/Source/Logger.swift
@@ -72,7 +72,7 @@ open class Logger {
     public private(set) var logLevels: LogLevel
 
     // This holds any message filters that have been provided.
-    public private(set) var filters: [LogFilter] = []
+    public private(set) var filters: [any LogFilter] = []
 
     /// The array of writers to use when messages are written.
     public let writers: [LogWriter]
@@ -115,7 +115,7 @@ open class Logger {
 
     /// Adds a log filter to the logger. A filter gives you dynamic control over whether logs are emitted or not, based on content in the ``LogMessage`` struct or message itself.
     /// - Parameter filter: A ``LogFilter`` instance to add.
-    public func addFilter(_ filter: LogFilter) {
+    public func addFilter(_ filter: any LogFilter) {
         executionMethod.perform {
             self.filters.append(filter)
         }

--- a/Source/Logger.swift
+++ b/Source/Logger.swift
@@ -71,6 +71,9 @@ open class Logger {
     /// Log levels this logger is configured for.
     public private(set) var logLevels: LogLevel
 
+    // This holds any message filters that have been provided.
+    public private(set) var filters: [LogFilter] = []
+
     /// The array of writers to use when messages are written.
     public let writers: [LogWriter]
 
@@ -95,6 +98,8 @@ open class Logger {
         self.executionMethod = executionMethod
     }
 
+    // MARK: -  Filtering & changing log levels
+
     /// Sets a new log level on the logger. Any previously logged messages will be emitted based on the setting
     /// at the time they were logged.
     /// - Parameter level: The new minimum log level
@@ -105,6 +110,29 @@ open class Logger {
             // ensures that messages enqueued after this call will be using the new log level
             // filter.
             self.logLevels = levels
+        }
+    }
+
+    /// Adds a log filter to the logger. A filter gives you dynamic control over whether logs are emitted or not, based on content in the ``LogMessage`` struct or message itself.
+    /// - Parameter filter: A ``LogFilter`` instance to add.
+    public func addFilter(_ filter: LogFilter) {
+        executionMethod.perform {
+            self.filters.append(filter)
+        }
+    }
+
+    /// Removes a named filter from the list of filters. Must have used a ``LogFilter`` that defines its own custom name.
+    /// - Parameter name: The name of the log filter, defined in the ``LogFilter`` protocol conformance.
+    public func removeFilter(named name: String) {
+        executionMethod.perform {
+            self.filters.removeAll(where: { $0.name == name })
+        }
+    }
+
+    /// Removes all log filters from the logger instance.
+    public func removeFilters() {
+        executionMethod.perform {
+            self.filters = []
         }
     }
 
@@ -296,12 +324,17 @@ open class Logger {
     }
 
     private func logMessage(_ message: String, with logLevel: LogLevel) {
+        guard filters.allSatisfy({ $0.shouldInclude(message, level: logLevel) }) else { return }
+
         writers.forEach { $0.writeMessage(message, logLevel: logLevel) }
     }
 
     private func logMessage(_ message: LogMessage, with logLevel: LogLevel) {
+        guard filters.allSatisfy({ $0.shouldInclude(message, level: logLevel) }) else { return }
+
         writers.forEach { $0.writeMessage(message, logLevel: logLevel) }
     }
+
 
     // MARK: - Private - No-Op Logger
 

--- a/Source/Logger.swift
+++ b/Source/Logger.swift
@@ -47,7 +47,9 @@ open class Logger {
         case synchronous(lock: NSRecursiveLock)
         case asynchronous(queue: DispatchQueue)
 
-        func perform(work: @escaping () -> Void) {
+        /// Performs a block of work using the desired synchronization method (either locks or serial queues).
+        /// - Parameter work: An escaping block of work that needs to be protected against data races.
+        public func perform(work: @escaping () -> Void) {
             switch self {
             case .synchronous(lock: let lock):
                 lock.lock()

--- a/Tests/LogFilterTests.swift
+++ b/Tests/LogFilterTests.swift
@@ -1,0 +1,86 @@
+//
+//  LogWriterTests.swift
+//
+//  Copyright (c) 2015-present Nike, Inc. (https://www.nike.com)
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+//
+
+import Foundation
+import os
+import Willow
+import XCTest
+
+struct TestLogFilter: LogFilter {
+    var name: String { "test" }
+
+    func shouldInclude(_ logMessage: LogMessage, level: LogLevel) -> Bool {
+        !logMessage.name.contains("EXCLUDE")
+    }
+
+    func shouldInclude(_ message: String, level: LogLevel) -> Bool {
+        !message.contains("EXCLUDE")
+    }
+}
+
+class MockWriter: LogWriter {
+    var messagesWritten: [String] = []
+    var logMessagesWritten: [LogMessage] = []
+
+    func writeMessage(_ message: String, logLevel: LogLevel) {
+        messagesWritten.append(message)
+    }
+
+    func writeMessage(_ message: LogMessage, logLevel: LogLevel) {
+        logMessagesWritten.append(message)
+    }
+}
+
+class LogFilterTests: XCTestCase {
+    var mockWriter: MockWriter!
+
+    override func setUp() {
+        mockWriter = MockWriter()
+    }
+
+    func testFilterMessages() {
+        let logger = Logger(logLevels: .all, writers: [mockWriter])
+        logger.addFilter(TestLogFilter())
+
+        logger.infoMessage("message 1")
+        logger.infoMessage("message 2 EXCLUDED")
+
+        XCTAssertEqual(mockWriter.messagesWritten.count, 1)
+        XCTAssertEqual(mockWriter.messagesWritten.last, "message 1")
+    }
+
+    func testRemovingFilters() {
+        let logger = Logger(logLevels: .all, writers: [mockWriter])
+        logger.addFilter(TestLogFilter())
+        logger.removeFilters()
+        XCTAssert(logger.filters.isEmpty)
+
+        logger.addFilter(TestLogFilter())
+        logger.removeFilter(named: "asdf")
+        XCTAssertEqual(logger.filters.count, 1)
+
+        logger.removeFilter(named: "test")
+        XCTAssert(logger.filters.isEmpty)
+    }
+}

--- a/Tests/LogLevelTests.swift
+++ b/Tests/LogLevelTests.swift
@@ -160,6 +160,16 @@ class LogLevelTestCase: XCTestCase {
 
         XCTAssertNotEqual(error, all)
     }
+
+    func testMinimumLogLevels() {
+        XCTAssertEqual(LogLevel.minimum(.all), .all)
+        XCTAssertEqual(LogLevel.minimum(.debug), .all)
+        XCTAssertEqual(LogLevel.minimum(.info), [.info, .event, .warn, .error])
+        XCTAssertEqual(LogLevel.minimum(.event), [.event, .warn, .error])
+        XCTAssertEqual(LogLevel.minimum(.warn), [.warn, .error])
+        XCTAssertEqual(LogLevel.minimum(.error), [.error])
+        XCTAssertEqual(LogLevel.minimum(.off), .off)
+    }
 }
 
 // MARK: -

--- a/Tests/LogModifierTests.swift
+++ b/Tests/LogModifierTests.swift
@@ -34,10 +34,10 @@ class TimestampModifierTestCase: XCTestCase {
         let logLevels: [LogLevel] = [.error, .warn, .event, .info, .debug]
 
         // When
-        var actualMessages = logLevels.map { modifier.modifyMessage(message, with: $0) }
+        let actualMessages = logLevels.map { modifier.modifyMessage(message, with: $0) }
 
         // Then
-        for (index, _) in logLevels.enumerated() {
+        for index in logLevels.indices {
             let actualMessage = actualMessages[index]
             let expectedSuffix = " \(message)"
             XCTAssertTrue(actualMessage.hasSuffix(expectedSuffix), "Actual message should contain expected suffix")

--- a/Willow.xcodeproj/project.pbxproj
+++ b/Willow.xcodeproj/project.pbxproj
@@ -7,6 +7,13 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		2F63041B2A4BA24900DB4099 /* LogFilter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F63041A2A4BA24900DB4099 /* LogFilter.swift */; };
+		2F63041C2A4BA24900DB4099 /* LogFilter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F63041A2A4BA24900DB4099 /* LogFilter.swift */; };
+		2F63041D2A4BA24900DB4099 /* LogFilter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F63041A2A4BA24900DB4099 /* LogFilter.swift */; };
+		2F63041E2A4BA24900DB4099 /* LogFilter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F63041A2A4BA24900DB4099 /* LogFilter.swift */; };
+		2F6304242A4C80F400DB4099 /* LogFilterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F63041F2A4C7FDC00DB4099 /* LogFilterTests.swift */; };
+		2F6304252A4C80F800DB4099 /* LogFilterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F63041F2A4C7FDC00DB4099 /* LogFilterTests.swift */; };
+		2F6304262A4C80F800DB4099 /* LogFilterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F63041F2A4C7FDC00DB4099 /* LogFilterTests.swift */; };
 		321F2DF335043A818DBEC881 /* (null) in Frameworks */ = {isa = PBXBuildFile; };
 		4C0CE38D1CFF3FB600D57B03 /* LogWriterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C0CE38C1CFF3FB600D57B03 /* LogWriterTests.swift */; };
 		4C0CE38E1CFF3FB600D57B03 /* LogWriterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C0CE38C1CFF3FB600D57B03 /* LogWriterTests.swift */; };
@@ -80,6 +87,8 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		2F63041A2A4BA24900DB4099 /* LogFilter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LogFilter.swift; sourceTree = "<group>"; };
+		2F63041F2A4C7FDC00DB4099 /* LogFilterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LogFilterTests.swift; sourceTree = "<group>"; };
 		4C0CE38C1CFF3FB600D57B03 /* LogWriterTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LogWriterTests.swift; sourceTree = "<group>"; };
 		4C1BBA691A6C518800D39EE1 /* LogModifierTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LogModifierTests.swift; sourceTree = "<group>"; };
 		4C1BBA6A1A6C518800D39EE1 /* LoggerTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LoggerTests.swift; sourceTree = "<group>"; };
@@ -180,6 +189,7 @@
 				4CA86F641AEC465E005E6475 /* LogModifier.swift */,
 				4CA86F671AEC466A005E6475 /* LogWriter.swift */,
 				4CA75D451A6C493F00275DC5 /* Supporting Files */,
+				2F63041A2A4BA24900DB4099 /* LogFilter.swift */,
 			);
 			path = Source;
 			sourceTree = "<group>";
@@ -199,6 +209,7 @@
 				557DA8311F3E1954005BC651 /* LoggerMessageStringTests.swift */,
 				557DA8351F3E1A9C005BC651 /* LoggerMessageTests.swift */,
 				4C1BBA6A1A6C518800D39EE1 /* LoggerTests.swift */,
+				2F63041F2A4C7FDC00DB4099 /* LogFilterTests.swift */,
 				4CBE850B1AEA2EFA006A1205 /* LogLevelTests.swift */,
 				4C1BBA691A6C518800D39EE1 /* LogModifierTests.swift */,
 				4C0CE38C1CFF3FB600D57B03 /* LogWriterTests.swift */,
@@ -572,6 +583,7 @@
 			files = (
 				4C88353A1C82530300F70419 /* LogWriter.swift in Sources */,
 				4C8835361C82530300F70419 /* LogModifier.swift in Sources */,
+				2F63041D2A4BA24900DB4099 /* LogFilter.swift in Sources */,
 				55B859C51F44FC9F0012F5F4 /* LogMessage.swift in Sources */,
 				4C8835371C82530300F70419 /* Logger.swift in Sources */,
 				4C8835391C82530300F70419 /* LogLevel.swift in Sources */,
@@ -588,6 +600,7 @@
 				4C88353E1C82530F00F70419 /* LoggerTests.swift in Sources */,
 				557DA8381F3E1A9C005BC651 /* LoggerMessageTests.swift in Sources */,
 				557DA8341F3E1954005BC651 /* LoggerMessageStringTests.swift in Sources */,
+				2F6304262A4C80F800DB4099 /* LogFilterTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -597,6 +610,7 @@
 			files = (
 				4CA33F381B7556FC0047C307 /* LogWriter.swift in Sources */,
 				4CA33F341B7556FC0047C307 /* LogModifier.swift in Sources */,
+				2F63041E2A4BA24900DB4099 /* LogFilter.swift in Sources */,
 				55B859C61F44FC9F0012F5F4 /* LogMessage.swift in Sources */,
 				4CA33F351B7556FC0047C307 /* Logger.swift in Sources */,
 				4CA33F371B7556FC0047C307 /* LogLevel.swift in Sources */,
@@ -609,6 +623,7 @@
 			files = (
 				4CA86F691AEC466A005E6475 /* LogWriter.swift in Sources */,
 				4CA86F661AEC465E005E6475 /* LogModifier.swift in Sources */,
+				2F63041C2A4BA24900DB4099 /* LogFilter.swift in Sources */,
 				55B859C41F44FC9F0012F5F4 /* LogMessage.swift in Sources */,
 				4C83FB2E1AEC1959003FEA49 /* LogLevel.swift in Sources */,
 				4CA86F631AEC4654005E6475 /* Logger.swift in Sources */,
@@ -625,6 +640,7 @@
 				4CC837791A6E347A00B31851 /* LoggerTests.swift in Sources */,
 				557DA8371F3E1A9C005BC651 /* LoggerMessageTests.swift in Sources */,
 				557DA8331F3E1954005BC651 /* LoggerMessageStringTests.swift in Sources */,
+				2F6304252A4C80F800DB4099 /* LogFilterTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -634,6 +650,7 @@
 			files = (
 				4CA86F681AEC466A005E6475 /* LogWriter.swift in Sources */,
 				4CA86F651AEC465E005E6475 /* LogModifier.swift in Sources */,
+				2F63041B2A4BA24900DB4099 /* LogFilter.swift in Sources */,
 				55B859C31F44FC9F0012F5F4 /* LogMessage.swift in Sources */,
 				4C83FB2D1AEC1959003FEA49 /* LogLevel.swift in Sources */,
 				4CA86F621AEC4654005E6475 /* Logger.swift in Sources */,
@@ -650,6 +667,7 @@
 				4C1BBA6B1A6C518800D39EE1 /* LogModifierTests.swift in Sources */,
 				557DA8361F3E1A9C005BC651 /* LoggerMessageTests.swift in Sources */,
 				557DA8321F3E1954005BC651 /* LoggerMessageStringTests.swift in Sources */,
+				2F6304242A4C80F400DB4099 /* LogFilterTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};


### PR DESCRIPTION
This PR adds 2 new features to Willow:

- The ability to change log levels at runtime
- A new `LogFilter` type that can allow apps to more deeply customize when a message will be logged

Both are gated around a new `perform` method on `ExecuteMethod`, which will either use recursive locks or serial queues, depending on which is configured for the logger to ensure thread safety.